### PR TITLE
Adds test for graal/issues/2776, Timezones

### DIFF
--- a/apps/timezones/pom.xml
+++ b/apps/timezones/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>timezone</groupId>
+    <artifactId>timezones</artifactId>
+    <version>1</version>
+
+    <name>timezones</name>
+
+    <parent>
+        <groupId>org.graalvm.tests.integration</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+
+    <properties>
+        <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
+    </properties>
+
+    <build>
+        <finalName>timezones</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven-jar-plugin.version}</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>timezone.Main</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/apps/timezones/src/main/java/timezone/Main.java
+++ b/apps/timezones/src/main/java/timezone/Main.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package timezone;
+
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.TimeZone;
+
+/**
+ * @author Severin Gehwolf <sgehwolf@redhat.com>
+ * @author Michal Karm Babacek <karm@redhat.com>
+ */
+public class Main {
+    public static void main(String[] args) {
+        System.out.println(String.format("%tc", new Date()));
+        final TimeZone tz = TimeZone.getTimeZone(ZoneId.of("Europe/Paris"));
+        System.out.println(tz.getDisplayName());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
                 <module>apps/micronaut-helloworld</module>
                 <module>apps/helidon-quickstart-se</module>
                 <module>apps/random-numbers</module>
+                <module>apps/timezones</module>
             </modules>
         </profile>
     </profiles>

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/Apps.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/Apps.java
@@ -53,7 +53,11 @@ public enum Apps {
     HELIDON_QUICKSTART_SE("apps" + File.separator + "helidon-quickstart-se",
             URLContent.HELIDON_QUICKSTART_SE,
             WhitelistLogLines.HELIDON_QUICKSTART_SE,
-            BuildAndRunCmds.HELIDON_QUICKSTART_SE);
+            BuildAndRunCmds.HELIDON_QUICKSTART_SE),
+    TIMEZONES("apps" + File.separator + "timezones",
+            URLContent.NONE,
+            WhitelistLogLines.NONE,
+            BuildAndRunCmds.TIMEZONES);
 
     public final String dir;
     public final URLContent urlContent;

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildAndRunCmds.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildAndRunCmds.java
@@ -46,6 +46,11 @@ public enum BuildAndRunCmds {
     HELIDON_QUICKSTART_SE(new String[][]{
             new String[]{"mvn", "package"},
             new String[]{Commands.isThisWindows ? "target\\helidon-quickstart-se" : "./target/helidon-quickstart-se"}
+    }),
+    TIMEZONES(new String[][]{
+            new String[]{"mvn", "package"},
+            new String[]{"native-image", "-J-Duser.country=CA", "-J-Duser.language=fr", "-jar", "target/timezones.jar", "target/timezones"},
+            new String[]{Commands.isThisWindows ? "target\\timezones" : "./target/timezones"}
     });
 
     public final String[][] cmds;

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/Logs.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/Logs.java
@@ -29,18 +29,14 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Scanner;
 import java.util.Set;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
-import static org.graalvm.tests.integration.RuntimesSmokeTest.BASE_DIR;
-import static org.graalvm.tests.integration.utils.Commands.isThisWindows;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.graalvm.tests.integration.RuntimesSmokeTest.BASE_DIR;
+import static org.graalvm.tests.integration.utils.Commands.isThisWindows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -52,6 +48,9 @@ public class Logs {
     public static final long SKIP = -1L;
 
     public static void checkLog(String testClass, String testMethod, Apps app, File log) throws IOException {
+        final Pattern[] whitelistPatterns = new Pattern[app.whitelistLogLines.errs.length + WhitelistLogLines.ALL.errs.length];
+        System.arraycopy(app.whitelistLogLines.errs, 0, whitelistPatterns, 0, app.whitelistLogLines.errs.length);
+        System.arraycopy(WhitelistLogLines.ALL.errs, 0, whitelistPatterns, app.whitelistLogLines.errs.length, WhitelistLogLines.ALL.errs.length);
         try (Scanner sc = new Scanner(log, UTF_8)) {
             Set<String> offendingLines = new HashSet<>();
             while (sc.hasNextLine()) {
@@ -59,7 +58,7 @@ public class Logs {
                 boolean error = warnErrorDetectionPattern.matcher(line).matches();
                 boolean whiteListed = false;
                 if (error) {
-                    for (Pattern p : app.whitelistLogLines.errs) {
+                    for (Pattern p : whitelistPatterns) {
                         if (p.matcher(line).matches()) {
                             whiteListed = true;
                             LOGGER.info(log.getName() + " log for " + testMethod + " contains whitelisted error: `" + line + "'");

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
@@ -27,6 +27,13 @@ import java.util.regex.Pattern;
  * @author Michal Karm Babacek <karm@redhat.com>
  */
 public enum WhitelistLogLines {
+
+    // This is appended to all undermentioned listings
+    ALL(new Pattern[]{
+            // https://github.com/graalvm/mandrel/issues/125
+            Pattern.compile(".*Using an older version of the labsjdk-11.*")
+    }),
+
     NONE(new Pattern[]{}),
 
     MICRONAUT_HELLOWORLD(new Pattern[]{


### PR DESCRIPTION
Mandrel 20.1
============

```
[ERROR] Failures:
[ERROR]   AppReproducersTest.timezonesBakedIn:194 `d’Europe centrale' string was expected.
  There might be a problem with timezones inclusion.
  See https://github.com/oracle/graal/issues/2776 ==> expected: <true> but was: <false>
[INFO]
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0
```

Mandrel 20.2
============

```
[o.g.t.i.AppReproducersTest] (timezonesBakedIn) Testing app: TIMEZONES
[o.g.t.i.AppReproducersTest] (timezonesBakedIn) Running...
[o.g.t.i.u.Logs] (checkLog) build-and-run.log log for timezonesBakedIn contains whitelisted error:
  `WARNING: Using an older version of the labsjdk-11.'
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 87.836 s - in org.graalvm.tests.integration.AppReproducersTest
```