### PR TITLE
Use quarkus.native.additional-build-args instead of additionalBuildArgs

### DIFF
--- a/apps/quarkus-full-microprofile/pom.xml
+++ b/apps/quarkus-full-microprofile/pom.xml
@@ -103,8 +103,6 @@
                         </executions>
                         <configuration>
                             <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                            <additionalBuildArgs>-H:Log=registerResource:</additionalBuildArgs>
-                            <additionalBuildArgs>-H:IncludeResources=privateKey.pem</additionalBuildArgs>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/apps/quarkus-full-microprofile/src/main/resources/application.properties
+++ b/apps/quarkus-full-microprofile/src/main/resources/application.properties
@@ -9,3 +9,4 @@ quarkus.jaeger.service-name=Demo-Service-A
 quarkus.jaeger.sampler-type=const
 quarkus.jaeger.sampler-param=1
 quarkus.jaeger.endpoint=http://localhost:14268/api/traces
+quarkus.native.additional-build-args=-H:Log=registerResource:,-H:IncludeResources=privateKey.pem


### PR DESCRIPTION
additionalBuildArgs is deprecated (see https://github.com/quarkusio/quarkus/issues/12666#issuecomment-707596054)