### PR TITLE
Remove obsolete libffi-devel dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,16 @@ Native image builds also require you have the following packages installed:
 * glibc-devel
 * zlib-devel
 * gcc
-* libffi-devel
 
 On Fedora/CentOS/RHEL they can be installed with:
 ```bash
-dnf install glibc-devel zlib-devel gcc libffi-devel libstdc++-static
+dnf install glibc-devel zlib-devel gcc libstdc++-static
 ```
 Note the package might be called `glibc-static` instead of `libstdc++-static`.
 
 On Ubuntu-like systems with:
 ```bash
-apt install gcc zlib1g-dev libffi-dev build-essential
+apt install gcc zlib1g-dev build-essential
 ```
 
 ## Usage


### PR DESCRIPTION
`libffi-devel` as of 20.1.0.3.Final is no longer needed (https://github.com/graalvm/mandrel/issues/158)