### PR TITLE
Adds test method annotation IfMandrelVersion

### DIFF
--- a/apps/versions/pom.xml
+++ b/apps/versions/pom.xml
@@ -12,7 +12,7 @@
         <groupId>org.graalvm.tests.integration</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../..</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <properties>
@@ -20,7 +20,7 @@
     </properties>
 
     <dependencies>
-	<dependency>
+        <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
             <version>20.3.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <vertx.auth.jwt.version>4.0.3</vertx.auth.jwt.version>
 
         <!-- Micronaut minimal app -->
-        <micronaut.version>2.4.2</micronaut.version>
+        <micronaut.version>2.3.0</micronaut.version>
 
         <!-- Helidon quickstart -->
         <version.helidon>2.2.2</version.helidon>
@@ -47,7 +47,7 @@
         <maven.build.helper.version>3.0.0</maven.build.helper.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <junit.jupiter.version>5.6.0</junit.jupiter.version>
+        <junit.jupiter.version>5.7.1</junit.jupiter.version>
         <resteasy.version>4.3.0.Final</resteasy.version>
         <commons.lang.version>3.9</commons.lang.version>
         <jboss-logging.version>3.4.1.Final</jboss-logging.version>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -50,6 +50,15 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- org.graalvm.home.Version used for filtering tests based on Graalvm/Mandrel version.
+             GraalVM sdk is not used for testing. You need Mandrel installed either locally or
+             in a builder image. -->
+        <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
+            <version>21.1.0</version>
+        </dependency>
+
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>

--- a/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
@@ -28,6 +28,7 @@ import org.graalvm.tests.integration.utils.GDBSession;
 import org.graalvm.tests.integration.utils.LogBuilder;
 import org.graalvm.tests.integration.utils.Logs;
 import org.graalvm.tests.integration.utils.WebpageTester;
+import org.graalvm.tests.integration.utils.versions.IfMandrelVersion;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -147,6 +148,7 @@ public class AppReproducersTest {
 
     @Test
     @Tag("imageio")
+    @IfMandrelVersion(min = "21.1")
     public void imageioAWTTest(TestInfo testInfo) throws IOException, InterruptedException {
         final Apps app = Apps.IMAGEIO;
         LOGGER.info("Testing app: " + app.toString());

--- a/testsuite/src/it/java/org/graalvm/tests/integration/RuntimesSmokeTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/RuntimesSmokeTest.java
@@ -25,6 +25,7 @@ import org.graalvm.tests.integration.utils.ContainerNames;
 import org.graalvm.tests.integration.utils.LogBuilder;
 import org.graalvm.tests.integration.utils.Logs;
 import org.graalvm.tests.integration.utils.WebpageTester;
+import org.graalvm.tests.integration.utils.versions.IfMandrelVersion;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
@@ -177,6 +178,7 @@ public class RuntimesSmokeTest {
 
     @Test
     @Tag("micronaut")
+    @IfMandrelVersion(min = "20.1.0.4", max = "20.3.2")
     public void micronautHelloWorld(TestInfo testInfo) throws IOException, InterruptedException {
         testRuntime(testInfo, Apps.MICRONAUT_HELLOWORLD);
     }

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/Commands.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/Commands.java
@@ -52,7 +52,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.graalvm.tests.integration.RuntimesSmokeTest.BASE_DIR;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -87,7 +86,7 @@ public class Commands {
             }
         }
         if (prop == null) {
-            LOGGER.warn("Failed to detect any of " + String.join(",", alternatives) +
+            LOGGER.info("Failed to detect any of " + String.join(",", alternatives) +
                     " as env or sys props, defaulting to " + defaultValue);
             return defaultValue;
         }
@@ -222,6 +221,17 @@ public class Commands {
             e.printStackTrace();
         }
         return pA;
+    }
+
+    public static String runCommand(List<String> command) throws IOException {
+        final ProcessBuilder processBuilder = new ProcessBuilder(command);
+        final Map<String, String> envA = processBuilder.environment();
+        envA.put("PATH", System.getenv("PATH"));
+        processBuilder.redirectErrorStream(true);
+        final Process p = processBuilder.start();
+        try (InputStream is = p.getInputStream()) {
+            return new String(is.readAllBytes(), StandardCharsets.UTF_8); // note that UTF-8 would mingle glyphs on Windows
+        }
     }
 
     public static Process runCommand(List<String> command, File directory, File logFile, Apps app, File input) {

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/IfMandrelVersion.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/IfMandrelVersion.java
@@ -28,13 +28,24 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
+ * Closed interval from min to max.
+ *
+ * e.g. closed interval [20.1, 20.3.2], as in 20.1 <= GRAALVM_VERSION <= 20.3.2
+ * translates to @IfMandrelVersion(min = "20.1", max="20.3.2").
+ *
  * Examples:
  *
  *     IfMandrelVersion(min = "20.1", max="20.3.2")
+ *     i.e. [20.1, 20.3.2]
  *
  *     IfMandrelVersion(min = "21.1", inContainer = true)
+ *     i.e. [21.1, +∞)
+ *
+ * Note that versions 21.1.0.0-final and 21.1.0.0-snapshot and 21.1.0.0 are all considered equal.
  *
  * The actual comparator comes from Graal's own org.graalvm.home.Version.
+ *
+ * inContainer: Whether the version should be pulled from a builder image container.
  *
  * @author Michal Karm Babacek <karm@redhat.com>
  */

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/IfMandrelVersion.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/IfMandrelVersion.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.graalvm.tests.integration.utils.versions;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Examples:
+ *
+ *     IfMandrelVersion(min = "20.1", max="20.3.2")
+ *
+ *     IfMandrelVersion(min = "21.1", inContainer = true)
+ *
+ * The actual comparator comes from Graal's own org.graalvm.home.Version.
+ *
+ * @author Michal Karm Babacek <karm@redhat.com>
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(MandrelVersionCondition.class)
+@Test
+public @interface IfMandrelVersion {
+    String min() default "";
+
+    String max() default "";
+
+    boolean inContainer() default false;
+}

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/MandrelVersionCondition.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/MandrelVersionCondition.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.graalvm.tests.integration.utils.versions;
+
+import org.graalvm.home.Version;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.io.IOException;
+import java.lang.reflect.AnnotatedElement;
+
+import static java.lang.String.format;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
+import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
+
+/**
+ * @author Michal Karm Babacek <karm@redhat.com>
+ */
+public class MandrelVersionCondition implements ExecutionCondition {
+
+    private static final ConditionEvaluationResult ENABLED_BY_DEFAULT =
+            enabled(
+                    "@IfMandrelVersion is not present");
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(
+            ExtensionContext context) {
+        AnnotatedElement element = context
+                .getElement()
+                .orElseThrow(IllegalStateException::new);
+        return findAnnotation(element, IfMandrelVersion.class)
+                .map(annotation -> disableIfVersionMismatch(annotation, element))
+                .orElse(ENABLED_BY_DEFAULT);
+    }
+
+    private ConditionEvaluationResult disableIfVersionMismatch(IfMandrelVersion annotation, AnnotatedElement element) {
+        try {
+            final Version usedVersion = UsedVersion.getVersion(annotation.inContainer());
+            if (annotation.min().isBlank() || usedVersion.compareTo(Version.parse(annotation.min())) >= 0) {
+                if (annotation.max().isBlank() || usedVersion.compareTo(Version.parse(annotation.max())) <= 0) {
+                    return enabled(format(
+                            "%s is enabled as Mandrel version %s does satisfy constraints: minVersion: %s, maxVersion: %s",
+                            element, usedVersion.toString(), annotation.min(), annotation.max()));
+                }
+            }
+            return disabled(format(
+                    "%s is disabled as Mandrel version %s does not satisfy constraints: minVersion: %s, maxVersion: %s",
+                    element, usedVersion.toString(), annotation.min(), annotation.max()));
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to get Mandrel version.", e);
+        }
+    }
+}

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/UsedVersion.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/UsedVersion.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.graalvm.tests.integration.utils.versions;
+
+import org.graalvm.home.Version;
+import org.graalvm.tests.integration.utils.Commands;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.graalvm.tests.integration.utils.Commands.BUILDER_IMAGE;
+import static org.graalvm.tests.integration.utils.Commands.CONTAINER_RUNTIME;
+
+/**
+ * Supported `native-image --version' output:
+ * GraalVM Version 20.1.0.4.Final (Mandrel Distribution) (Java Version 11.0.10+9)
+ * native-image 21.1.0.0-Final (Mandrel Distribution) (Java Version 11.0.11+9)
+ *
+ * @author Michal Karm Babacek <karm@redhat.com>
+ */
+public class UsedVersion {
+    private static Version version = null;
+    private static Version versionInContainer = null;
+
+    private static final Logger LOGGER = Logger.getLogger(UsedVersion.class.getName());
+
+    private enum VersionType {
+        OLD,
+        NEW,
+        INVALID
+    }
+
+    private static VersionType getVersionType(String[] parts) {
+        if (parts.length > 2) {
+            if ("native-image".equals(parts[0])) {
+                return VersionType.NEW;
+            }
+            if ("GraalVM".equals(parts[0])) {
+                return VersionType.OLD;
+            }
+        }
+        return VersionType.INVALID;
+    }
+
+    private static Version parseVersion(VersionType versionType, String[] parts) {
+        final String v = (versionType == VersionType.NEW) ? parts[1] : parts[2];
+        // Invalid version string '20.1.0.4.Final'
+        final String sanitized = v.toLowerCase()
+                .replace(".f", "-f")
+                .replace(".s", "-s");
+        return Version.parse(sanitized);
+    }
+
+    public static Version getVersion(boolean inContainer) throws IOException {
+        if (inContainer) {
+            if (versionInContainer == null) {
+                final List<String> cmd = List.of(CONTAINER_RUNTIME, "run", "-t", BUILDER_IMAGE, "native-image", "--version");
+                LOGGER.info("Running command " + cmd.toString() + " to determine Mandrel version used.");
+                final String out = Commands.runCommand(cmd);
+                final String[] lines = out.split(System.lineSeparator());
+                final String lastLine = lines[lines.length - 1];
+                final String[] parts = lastLine.split(" ");
+                final VersionType versionType = getVersionType(parts);
+                if (versionType == VersionType.INVALID) {
+                    throw new IllegalArgumentException("native-image command failed. " +
+                            "Is " + CONTAINER_RUNTIME + " running and image " + BUILDER_IMAGE + " available? " +
+                            "Output: " + lastLine);
+                }
+                versionInContainer = parseVersion(versionType, parts);
+                LOGGER.info("The test suite runs with Mandrel version " + versionInContainer.toString() + " in container.");
+            }
+            return versionInContainer;
+        }
+
+        if (version == null) {
+            final List<String> cmd = List.of("native-image", "--version");
+            LOGGER.info("Running command " + cmd.toString() + " to determine Mandrel version used.");
+            final String line = Commands.runCommand(cmd);
+            final String[] parts = line.split(" ");
+            final VersionType versionType = getVersionType(parts);
+            if (versionType == VersionType.INVALID) {
+                throw new IllegalArgumentException("native-image command failed. " +
+                        "Is it on PATH? " +
+                        "Output: " + line);
+            }
+            version = parseVersion(versionType, parts);
+            LOGGER.info("The test suite runs with Mandrel version " + version.toString() + " installed locally on PATH.");
+        }
+        return version;
+    }
+}


### PR DESCRIPTION

Examples:

```
    @IfMandrelVersion(min = "20.1", max="20.3.2")
    
    @IfMandrelVersion(min = "21.1", inContainer = true)
    
    @IfMandrelVersion(min = "20.1.0.4", max = "20.3.2")
    
    @IfMandrelVersion(min = "21.1")
```

The actual comparator comes from Graal's own org.graalvm.home.Version.

The version detected is spit out in the log:

```
INFO  [o.g.t.i.u.v.UsedVersion] (getVersion) Running command [native-image, --version] to determine Mandrel version used.
INFO  [o.g.t.i.u.v.UsedVersion] (getVersion) The test suite runs with Mandrel version 20.3.2-final installed locally on PATH.
INFO  [o.g.t.i.u.v.UsedVersion] (getVersion) Running command [docker, run, -t, quay.io/quarkus/ubi-quarkus-mandrel:20.1-java11, native-image, --version] to determine Mandrel version used.
INFO  [o.g.t.i.u.v.UsedVersion] (getVersion) The test suite runs with Mandrel version 20.1.0.4-final in container.
```

If no annotation with `inContainer = true` is used (any such test activated), TS does not attempt to run any containers:

```
INFO  [o.g.t.i.u.v.UsedVersion] (getVersion) Running command [native-image, --version] to determine Mandrel version used.
INFO  [o.g.t.i.u.v.UsedVersion] (getVersion) The test suite runs with Mandrel version 21.1.0-snapshot installed locally on PATH.
```