### PR TITLE
JFR tests are also built in a builder container now

### DIFF
--- a/.github/workflows/builder_image_tests.yml
+++ b/.github/workflows/builder_image_tests.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        quarkus-version: ['1.11.7.Final', '2.1.0.Final']
+        quarkus-version: ['1.11.7.Final', '2.2.3.Final']
         mandrel-builder-image: [
             '20.3-java11',
             '21.2-java11'

--- a/.github/workflows/local_tests.yml
+++ b/.github/workflows/local_tests.yml
@@ -22,12 +22,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        quarkus-version: ['1.11.7.Final', '2.1.0.Final']
-        mandrel-version: ['21.2.0.0-Final', '20.3.2.0-Final']
+        quarkus-version: ['1.11.7.Final', '2.2.3.Final']
+        mandrel-version: ['21.2.0.1-Final', '20.3.3.0-Final']
         os: [ubuntu-20.04, windows-2019]
         exclude:
           - quarkus-version: '1.11.7.Final'
-            mandrel-version: '21.2.0.0-Final'
+            mandrel-version: '21.2.0.1-Final'
     steps:
       - uses: actions/checkout@v2
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <!-- Quarkus apps -->
         <!-- Note that the TS switches Quarkus version at test run,
              see Commands.java, QUARKUS_VERSION -->
-        <global.quarkus.version>2.1.0.Final</global.quarkus.version>
+        <global.quarkus.version>2.2.3.Final</global.quarkus.version>
 
         <!-- Micronaut minimal app -->
         <micronaut.version>2.3.0</micronaut.version>

--- a/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
@@ -81,7 +81,7 @@ public class AppReproducersTest {
     @Tag("randomNumbers")
     public void randomNumbersReinit(TestInfo testInfo) throws IOException, InterruptedException {
         final Apps app = Apps.RANDOM_NUMBERS;
-        LOGGER.info("Testing app: " + app.toString());
+        LOGGER.info("Testing app: " + app);
         Process process = null;
         File processLog = null;
         final StringBuilder report = new StringBuilder();
@@ -242,7 +242,7 @@ public class AppReproducersTest {
             //TODO: This might be too fragile... e.g. order shouldn't matter.
             final String toFind;
             // Harfbuzz removed: https://github.com/graalvm/mandrel/issues/286
-            if(Runtime.version().feature() > 11 || Runtime.version().update() > 12) {
+            if (Runtime.version().feature() > 11 || Runtime.version().update() > 12) {
                 toFind = "libnet.a|libjavajpeg.a|libnio.a|liblibchelper.a|libjava.a|liblcms.a|libfontmanager.a|libawt_headless.a|libawt.a|libfdlibm.a|libzip.a|libjvm.a";
             } else {
                 toFind = "libnet.a|libjavajpeg.a|libnio.a|liblibchelper.a|libjava.a|liblcms.a|libfontmanager.a|libawt_headless.a|libawt.a|libharfbuzz.a|libfdlibm.a|libzip.a|libjvm.a";
@@ -272,7 +272,7 @@ public class AppReproducersTest {
     @Tag("timezones")
     public void timezonesBakedIn(TestInfo testInfo) throws IOException, InterruptedException {
         final Apps app = Apps.TIMEZONES;
-        LOGGER.info("Testing app: " + app.toString());
+        LOGGER.info("Testing app: " + app);
         Process process = null;
         File processLog = null;
         final StringBuilder report = new StringBuilder();
@@ -345,7 +345,7 @@ public class AppReproducersTest {
     @Tag("versions")
     public void versionsParsingMandrel(TestInfo testInfo) throws IOException, InterruptedException {
         final Apps app = Apps.VERSIONS;
-        LOGGER.info("Testing app: " + app.toString());
+        LOGGER.info("Testing app: " + app);
         Process process = null;
         File processLog = null;
         final StringBuilder report = new StringBuilder();
@@ -390,7 +390,7 @@ public class AppReproducersTest {
     @Tag("nativeJVMTextProcessing")
     public void nativeJVMTextProcessing(TestInfo testInfo) throws IOException, InterruptedException {
         final Apps app = Apps.DEBUG_SYMBOLS_SMOKE;
-        LOGGER.info("Testing app: " + app.toString());
+        LOGGER.info("Testing app: " + app);
         Process process = null;
         File processLog = null;
         final StringBuilder report = new StringBuilder();
@@ -469,11 +469,11 @@ public class AppReproducersTest {
         }
 
         LogBuilder.Log logJVM = new LogBuilder()
-                .app(app.toString() + "_JVM" + suffixUpper)
+                .app(app + "_JVM" + suffixUpper)
                 .timeToFinishMs(jvmRunTookMs)
                 .build();
         LogBuilder.Log logNative = new LogBuilder()
-                .app(app.toString() + "_NATIVE" + suffixUpper)
+                .app(app + "_NATIVE" + suffixUpper)
                 .timeToFinishMs(nativeRunTookMs)
                 .build();
         Logs.logMeasurements(logJVM, measurementsLog);

--- a/testsuite/src/it/java/org/graalvm/tests/integration/DebugSymbolsTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/DebugSymbolsTest.java
@@ -85,7 +85,7 @@ public class DebugSymbolsTest {
     @DisabledOnOs({OS.WINDOWS})
     public void debugSymbolsSmokeGDB(TestInfo testInfo) throws IOException, InterruptedException {
         final Apps app = Apps.DEBUG_SYMBOLS_SMOKE;
-        LOGGER.info("Testing app: " + app.toString());
+        LOGGER.info("Testing app: " + app);
         File processLog = null;
         final StringBuilder report = new StringBuilder();
         final File appDir = new File(BASE_DIR + File.separator + app.dir);
@@ -129,8 +129,8 @@ public class DebugSymbolsTest {
                 Logs.appendlnSection(report, String.join(" ", processBuilder.command()));
                 Logs.appendln(report, stringBuffer.toString());
                 assertTrue(waitForBufferToMatch(stringBuffer,
-                        Pattern.compile(".*Reading symbols from.*", Pattern.DOTALL),
-                        3000, 500, TimeUnit.MILLISECONDS),
+                                Pattern.compile(".*Reading symbols from.*", Pattern.DOTALL),
+                                3000, 500, TimeUnit.MILLISECONDS),
                         "GDB session did not start well. Check the names, paths... Content was: " + stringBuffer.toString());
 
                 carryOutGDBSession(stringBuffer, GDBSession.DEBUG_SYMBOLS_SMOKE, esvc, writer, report, UsedVersion.getVersion(false));
@@ -152,7 +152,7 @@ public class DebugSymbolsTest {
     @DisabledOnOs({OS.WINDOWS})
     public void debugSymbolsQuarkus(TestInfo testInfo) throws IOException, InterruptedException {
         final Apps app = Apps.DEBUG_QUARKUS_FULL_MICROPROFILE;
-        LOGGER.info("Testing app: " + app.toString());
+        LOGGER.info("Testing app: " + app);
         File processLog = null;
         final StringBuilder report = new StringBuilder();
         final File appDir = new File(BASE_DIR + File.separator + app.dir);
@@ -199,8 +199,8 @@ public class DebugSymbolsTest {
                 Logs.appendlnSection(report, String.join(" ", processBuilder.command()));
                 Logs.appendln(report, stringBuffer.toString());
                 assertTrue(waitForBufferToMatch(stringBuffer,
-                        Pattern.compile(".*Reading symbols from.*", Pattern.DOTALL),
-                        3000, 500, TimeUnit.MILLISECONDS),
+                                Pattern.compile(".*Reading symbols from.*", Pattern.DOTALL),
+                                3000, 500, TimeUnit.MILLISECONDS),
                         "GDB session did not start well. Check the names, paths... Content was: " + stringBuffer.toString());
 
                 writer.write("set confirm off\n");
@@ -232,7 +232,7 @@ public class DebugSymbolsTest {
     @DisabledOnOs({OS.WINDOWS})
     public void debugSymbolsQuarkusContainer(TestInfo testInfo) throws IOException, InterruptedException {
         final Apps app = Apps.DEBUG_QUARKUS_BUILDER_IMAGE_VERTX;
-        LOGGER.info("Testing app: " + app.toString());
+        LOGGER.info("Testing app: " + app);
         File processLog = null;
         final StringBuilder report = new StringBuilder();
         final File appDir = new File(BASE_DIR + File.separator + app.dir);
@@ -286,8 +286,8 @@ public class DebugSymbolsTest {
                 Logs.appendlnSection(report, String.join(" ", processBuilder.command()));
                 Logs.appendln(report, stringBuffer.toString());
                 assertTrue(waitForBufferToMatch(stringBuffer,
-                        Pattern.compile(".*Reading symbols from.*", Pattern.DOTALL),
-                        3000, 500, TimeUnit.MILLISECONDS),
+                                Pattern.compile(".*Reading symbols from.*", Pattern.DOTALL),
+                                3000, 500, TimeUnit.MILLISECONDS),
                         "GDB session did not start well. Check the names, paths... Content was: " + stringBuffer.toString());
 
                 writer.write("set confirm off\n");

--- a/testsuite/src/it/java/org/graalvm/tests/integration/RuntimesSmokeTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/RuntimesSmokeTest.java
@@ -75,7 +75,7 @@ public class RuntimesSmokeTest {
     public static final String BASE_DIR = getBaseDir();
 
     public void testRuntime(TestInfo testInfo, Apps app) throws IOException, InterruptedException {
-        LOGGER.info("Testing app: " + app.toString());
+        LOGGER.info("Testing app: " + app);
         Process process = null;
         final File appDir = new File(BASE_DIR + File.separator + app.dir);
         final File processLog = new File(appDir.getAbsolutePath() + File.separator + "logs" + File.separator + "build-and-run.log");

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/Apps.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/Apps.java
@@ -104,11 +104,21 @@ public enum Apps {
             WhitelistLogLines.JFR,
             BuildAndRunCmds.JFR_SMOKE,
             ContainerNames.NONE),
+    JFR_SMOKE_BUILDER_IMAGE("apps" + File.separator + "debug-symbols-smoke",
+            URLContent.NONE,
+            WhitelistLogLines.JFR,
+            BuildAndRunCmds.JFR_SMOKE_BUILDER_IMAGE,
+            ContainerNames.JFR_SMOKE_BUILDER_IMAGE),
     JFR_OPTIONS("apps" + File.separator + "timezones",
             URLContent.NONE,
             WhitelistLogLines.JFR,
             BuildAndRunCmds.JFR_OPTIONS,
-            ContainerNames.NONE);
+            ContainerNames.NONE),
+    JFR_OPTIONS_BUILDER_IMAGE("apps" + File.separator + "timezones",
+            URLContent.NONE,
+            WhitelistLogLines.JFR,
+            BuildAndRunCmds.JFR_OPTIONS_BUILDER_IMAGE,
+            ContainerNames.JFR_SMOKE_BUILDER_IMAGE);
 
     public final String dir;
     public final URLContent urlContent;

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildAndRunCmds.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildAndRunCmds.java
@@ -154,9 +154,41 @@ public enum BuildAndRunCmds {
                     "-XX:StartFlightRecording=filename=logs/flight-native.jfr",
                     "-XX:FlightRecorderLogging=jfr"}
     }),
+    JFR_SMOKE_BUILDER_IMAGE(new String[][]{
+            new String[]{"mvn", "package"},
+            new String[]{"unzip", "test_data.txt.zip", "-d", "target"},
+            new String[]{
+                    CONTAINER_RUNTIME, "run", "-u", IS_THIS_WINDOWS ? "" : getUnixUIDGID(),
+                    "-t", "-v", BASE_DIR + File.separator + "apps" + File.separator + "debug-symbols-smoke:/project:z",
+                    "--name", ContainerNames.JFR_SMOKE_BUILDER_IMAGE.name + "-build",
+                    BUILDER_IMAGE, "-H:+AllowVMInspection", "-jar", "target/debug-symbols-smoke.jar", "target/debug-symbols-smoke"},
+            new String[]{
+                    CONTAINER_RUNTIME, "run", "-u", IS_THIS_WINDOWS ? "" : getUnixUIDGID(),
+                    "-i",
+                    "--entrypoint", "java", "-v", BASE_DIR + File.separator + "apps" + File.separator + "debug-symbols-smoke:/project:z",
+                    "--name", ContainerNames.JFR_SMOKE_BUILDER_IMAGE.name + "-run",
+                    BUILDER_IMAGE,
+                    "-XX:+FlightRecorder",
+                    "-XX:StartFlightRecording=filename=logs/flight-java.jfr",
+                    "-Xlog:jfr", "-jar", "./target/debug-symbols-smoke.jar"},
+            new String[]{
+                    "./target/debug-symbols-smoke",
+                    "-XX:+FlightRecorder",
+                    "-XX:StartFlightRecording=filename=logs/flight-native.jfr",
+                    "-XX:FlightRecorderLogging=jfr"}
+    }),
     JFR_OPTIONS(new String[][]{
             new String[]{"mvn", "package"},
             new String[]{"native-image", "-H:+AllowVMInspection", "-jar", "target/timezones.jar", "target/timezones"}
+            // @see JFRTest.java
+    }),
+    JFR_OPTIONS_BUILDER_IMAGE(new String[][]{
+            new String[]{"mvn", "package"},
+            new String[]{
+                    CONTAINER_RUNTIME, "run", "-u", IS_THIS_WINDOWS ? "" : getUnixUIDGID(),
+                    "-t", "-v", BASE_DIR + File.separator + "apps" + File.separator + "timezones:/project:z",
+                    "--name", ContainerNames.JFR_SMOKE_BUILDER_IMAGE.name + "-build",
+                    BUILDER_IMAGE, "-H:+AllowVMInspection", "-jar", "target/timezones.jar", "target/timezones"}
             // @see JFRTest.java
     });
 

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/Commands.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/Commands.java
@@ -74,7 +74,7 @@ public class Commands {
             getProperty(new String[]{"PODMAN_WITH_SUDO", "podman.with.sudo"}, "true"));
     public static final String QUARKUS_VERSION = getProperty(
             new String[]{"QUARKUS_VERSION", "quarkus.version"},
-            "2.1.0.Final");
+            "2.2.3.Final");
     public static final boolean IS_THIS_WINDOWS = System.getProperty("os.name").matches(".*[Ww]indows.*");
     private static final Pattern NUM_PATTERN = Pattern.compile("[ \t]*[0-9]+[ \t]*");
     private static final Pattern ALPHANUMERIC_FIRST = Pattern.compile("([a-z0-9]+).*");

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/ContainerNames.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/ContainerNames.java
@@ -27,7 +27,8 @@ package org.graalvm.tests.integration.utils;
 public enum ContainerNames {
     QUARKUS_BUILDER_IMAGE_ENCODING("my-quarkus-mandrel-app-container"),
     DEBUG_QUARKUS_BUILDER_IMAGE_VERTX("my-quarkus-mandrel-app-container"), // Probably no reason to call them differently?
-    IMAGEIO_BUILDER_IMAGE("karm/my-imageio-runner"),
+    IMAGEIO_BUILDER_IMAGE("my-imageio-runner"),
+    JFR_SMOKE_BUILDER_IMAGE("my-jfr-smoke-runner"),
     NONE("NO_CONTAINER");
 
     public final String name;

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/Logs.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/Logs.java
@@ -92,7 +92,8 @@ public class Logs {
                 long executableSizeThresholdKb = app.thresholdProperties.get(key);
                 assertTrue(executableSizeKb <= executableSizeThresholdKb,
                         "Application " + app + (mode != null ? " in mode " + mode : "") + " executable size is " +
-                                executableSizeKb + " kB, which is over " + executableSizeThresholdKb + " kB threshold.");
+                                executableSizeKb + " kB, which is over " +
+                                executableSizeThresholdKb + " kB threshold by " + percentageValOverTh(executableSizeKb, executableSizeThresholdKb) + "%.");
             } else {
                 LOGGER.error("executableSizeKb was to be checked, but there is no " + key + " in " +
                         Path.of(BASE_DIR, app.dir, "threshold.properties"));
@@ -106,7 +107,7 @@ public class Logs {
                 assertTrue(timeToFirstOKRequest <= timeToFirstOKRequestThresholdMs,
                         "Application " + app + (mode != null ? " in mode " + mode : "") +
                                 " took " + timeToFirstOKRequest + " ms to get the first OK request, which is over " +
-                                timeToFirstOKRequestThresholdMs + " ms threshold.");
+                                timeToFirstOKRequestThresholdMs + " ms threshold by " + percentageValOverTh(timeToFirstOKRequest, timeToFirstOKRequestThresholdMs) + "%.");
             } else {
                 LOGGER.error("timeToFirstOKRequest was to be checked, but there is no " + key + " in " +
                         Path.of(BASE_DIR, app.dir, "threshold.properties"));
@@ -119,7 +120,8 @@ public class Logs {
                 long rssThresholdKb = app.thresholdProperties.get(key);
                 assertTrue(rssKb <= rssThresholdKb,
                         "Application " + app + (mode != null ? " in mode " + mode : "") +
-                                " consumed " + rssKb + " kB or RSS memory, which is over " + rssThresholdKb + " kB threshold.");
+                                " consumed " + rssKb + " kB or RSS memory, which is over " +
+                                rssThresholdKb + " kB threshold by " + percentageValOverTh(rssKb, rssThresholdKb) + "%.");
             } else {
                 LOGGER.error("rssKb was to be checked, but there is no " + key + " in " +
                         Path.of(BASE_DIR, app.dir, "threshold.properties"));
@@ -133,12 +135,16 @@ public class Logs {
                 assertTrue(timeToFinishMs <= timeToFinishThresholdMs,
                         "Application " + app + (mode != null ? " in mode " + mode : "") + " took " +
                                 timeToFinishMs + " ms to finish, which is over " +
-                                timeToFinishThresholdMs + " ms threshold.");
+                                timeToFinishThresholdMs + " ms threshold by " + percentageValOverTh(timeToFinishMs, timeToFinishThresholdMs) + "%.");
             } else {
                 LOGGER.error("timeToFinishMs was to be checked, but there is no " + key + " in " +
                         Path.of(BASE_DIR, app.dir, "threshold.properties"));
             }
         }
+    }
+
+    public static int percentageValOverTh(float value, float threshold) {
+        return Math.round(value / (threshold / 100f)) - 100;
     }
 
     public static void checkThreshold(Apps app, long executableSizeKb, long rssKb, long timeToFirstOKRequest) {

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
@@ -74,7 +74,10 @@ public enum WhitelistLogLines {
             // Windows specific warning, O.K.
             Pattern.compile(".*objcopy executable not found in PATH.*"),
             Pattern.compile(".*That will result in a larger native image.*"),
+            Pattern.compile(".*That also means that resulting native executable is larger*"),
             Pattern.compile(".*contain duplicate files, e.g. javax/activation/ActivationDataFlavor.class.*"),
+            Pattern.compile(".*contain duplicate files, e.g. javax/servlet/http/HttpUtils.class.*"),
+            Pattern.compile(".*contain duplicate files, e.g. javax/annotation/ManagedBean.class.*"),
             // Jaeger Opentracing initialization, Quarkus 2.x specific issue.
             Pattern.compile(".*io.jaegertracing.internal.exceptions.SenderException:.*"),
             // Jaeger Opentracing, Quarkus 2.x specific issue.

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/MandrelVersionCondition.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/MandrelVersionCondition.java
@@ -64,8 +64,8 @@ public class MandrelVersionCondition implements ExecutionCondition {
             }
             return disabled(format(
                     "%s is disabled as Mandrel version %s does not satisfy constraints: minVersion: %s, maxVersion: %s",
-                    element, usedVersion.toString(), annotation.min(), annotation.max()));
-        } catch (IOException e) {
+                    element, usedVersion, annotation.min(), annotation.max()));
+        } catch (IOException | InterruptedException e) {
             throw new RuntimeException("Unable to get Mandrel version.", e);
         }
     }


### PR DESCRIPTION
JFR tests were limited to locally installed Mandrel and some options tests were limited to version 21.3.
This patch enabled JFR tests to be built in a builder container and lowers the min version to 21.2 since the patch for https://github.com/oracle/graal/issues/3638 was backported.

e.g. 

## Older 21.2, unpatched :x: 
```
2021-10-01 14:17:34.848 INFO  [o.g.t.i.u.v.UsedVersion] (getVersion) The test suite runs with Mandrel version 21.2.0-0b3 in container.
2021-10-01 14:17:34.876 INFO  [o.g.t.i.JFRTest] (jfrOptionsSmoke) Testing app: JFR_OPTIONS_BUILDER_IMAGE
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 69.094 s <<< FAILURE! - in org.graalvm.tests.integration.JFRTest
[ERROR] jfrOptionsSmokeContainerTest{TestInfo}  Time elapsed: 39.958 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: 
Command `./target/timezones -XX:+FlightRecorder -XX:StartFlightRecording=maxsize=10k,filename=logs/flight-native.jfr -XX:FlightRecorderLogging=jfr' output did not match expected pattern `.* Started recording .* \{maxsize=10.0kB.*', it was: ./target/timezones -XX:+FlightRecorder -XX:StartFlightRecording=maxsize=10k,filename=logs/flight-native.jfr -XX:FlightRecorderLogging=jfr
Exception in thread "main" com.oracle.svm.core.util.UserError$UserException: Could not parse JFR argument 'maxsize=10k'. Expected a number.
    at com.oracle.svm.core.util.UserError.abort(UserError.java:68)
    at com.oracle.svm.jfr.JfrManager.parseLong(JfrManager.java:171)
    at com.oracle.svm.jfr.JfrManager.initRecording(JfrManager.java:107)
    at com.oracle.svm.jfr.JfrManager.setup(JfrManager.java:72)
    at com.oracle.svm.core.jdk.RuntimeSupport.executeHooks(RuntimeSupport.java:125)
    at com.oracle.svm.core.jdk.RuntimeSupport.executeStartupHooks(RuntimeSupport.java:75)
 ==> expected: <true> but was: <false>
    at org.graalvm.tests.integration.JFRTest.jfrOptionsSmoke(JFRTest.java:279)
    at org.graalvm.tests.integration.JFRTest.jfrOptionsSmokeContainerTest(JFRTest.java:150)
```

## Patched 21.2 :heavy_check_mark: 
```
2021-10-01 14:18:53.823 INFO  [o.g.t.i.u.v.UsedVersion] (getVersion) The test suite runs with Mandrel version 21.2.0.1-0b2 in container.
2021-10-01 14:18:53.851 INFO  [o.g.t.i.JFRTest] (jfrOptionsSmoke) Testing app: JFR_OPTIONS_BUILDER_IMAGE
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 39.914 s - in org.graalvm.tests.integration.JFRTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```