### PR TITLE
The artifact quarkus-vertx-web is now named quarkus-reactive-routes

### DIFF
--- a/builder-image-apps/quarkus-vertx/quarkus_main.patch
+++ b/builder-image-apps/quarkus-vertx/quarkus_main.patch
@@ -1,0 +1,13 @@
+diff --git a/builder-image-apps/quarkus-vertx/pom.xml b/builder-image-apps/quarkus-vertx/pom.xml
+index 4bbe1d3..7d47c9b 100644
+--- a/builder-image-apps/quarkus-vertx/pom.xml
++++ b/builder-image-apps/quarkus-vertx/pom.xml
+@@ -48,7 +48,7 @@
+         </dependency>
+         <dependency>
+             <groupId>io.quarkus</groupId>
+-            <artifactId>quarkus-vertx-web</artifactId>
++            <artifactId>quarkus-reactive-routes</artifactId>
+         </dependency>
+         <dependency>
+             <groupId>io.quarkus</groupId>

--- a/testsuite/src/it/java/org/graalvm/tests/integration/DebugSymbolsTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/DebugSymbolsTest.java
@@ -255,6 +255,9 @@ public class DebugSymbolsTest {
             if (QUARKUS_VERSION.startsWith("2.4")) {
                 runCommand(getRunCommand("git", "apply", "quarkus_2.4.x.patch"),
                         Path.of(BASE_DIR, Apps.DEBUG_QUARKUS_BUILDER_IMAGE_VERTX.dir).toFile());
+            } else if (QUARKUS_VERSION.contains("SNAPSHOT")) {
+                runCommand(getRunCommand("git", "apply", "quarkus_main.patch"),
+                        Path.of(BASE_DIR, Apps.DEBUG_QUARKUS_BUILDER_IMAGE_VERTX.dir).toFile());
             }
 
             // Build & Run


### PR DESCRIPTION
Closes: #63

Note: A potential issue with this patch is that it won't work with snapshots from Quarkus versions before the artifact renaming.