### PR TITLE
Recognizes LTS version in prod builder image, JDK version parsed

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/RuntimesSmokeTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/RuntimesSmokeTest.java
@@ -202,7 +202,6 @@ public class RuntimesSmokeTest {
         }
     }
 
-
     @Test
     @Tag("builder-image")
     @Tag("quarkus")

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/CP.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/CP.java
@@ -23,6 +23,7 @@ import java.util.regex.Pattern;
 
 /**
  * Utility struct
+ *
  * @author Michal Karm Babacek <karm@redhat.com>
  */
 public class CP {

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/IfMandrelVersion.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/IfMandrelVersion.java
@@ -32,7 +32,7 @@ import java.lang.annotation.Target;
  *
  * e.g. closed interval [20.1, 20.3.2], as in 20.1 <= GRAALVM_VERSION <= 20.3.2
  * translates to @IfMandrelVersion(min = "20.1", max="20.3.2").
- *
+ * //@formatter:off
  * Examples:
  *
  *     IfMandrelVersion(min = "20.1", max="20.3.2")
@@ -40,7 +40,7 @@ import java.lang.annotation.Target;
  *
  *     IfMandrelVersion(min = "21.1", inContainer = true)
  *     i.e. [21.1, +∞)
- *
+ * //@formatter:on
  * Note that versions 21.1.0.0-final and 21.1.0.0-snapshot and 21.1.0.0 are all considered equal.
  *
  * The actual comparator comes from Graal's own org.graalvm.home.Version.

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/MandrelVersionCondition.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/MandrelVersionCondition.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-import java.io.IOException;
 import java.lang.reflect.AnnotatedElement;
 
 import static java.lang.String.format;
@@ -38,8 +37,7 @@ import static org.junit.platform.commons.support.AnnotationSupport.findAnnotatio
 public class MandrelVersionCondition implements ExecutionCondition {
 
     private static final ConditionEvaluationResult ENABLED_BY_DEFAULT =
-            enabled(
-                    "@IfMandrelVersion is not present");
+            enabled("@IfMandrelVersion is not present");
 
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(
@@ -53,20 +51,16 @@ public class MandrelVersionCondition implements ExecutionCondition {
     }
 
     private ConditionEvaluationResult disableIfVersionMismatch(IfMandrelVersion annotation, AnnotatedElement element) {
-        try {
-            final Version usedVersion = UsedVersion.getVersion(annotation.inContainer());
-            if (annotation.min().isBlank() || usedVersion.compareTo(Version.parse(annotation.min())) >= 0) {
-                if (annotation.max().isBlank() || usedVersion.compareTo(Version.parse(annotation.max())) <= 0) {
-                    return enabled(format(
-                            "%s is enabled as Mandrel version %s does satisfy constraints: minVersion: %s, maxVersion: %s",
-                            element, usedVersion.toString(), annotation.min(), annotation.max()));
-                }
+        final Version usedVersion = UsedVersion.getVersion(annotation.inContainer());
+        if (annotation.min().isBlank() || usedVersion.compareTo(Version.parse(annotation.min())) >= 0) {
+            if (annotation.max().isBlank() || usedVersion.compareTo(Version.parse(annotation.max())) <= 0) {
+                return enabled(format(
+                        "%s is enabled as Mandrel version %s does satisfy constraints: minVersion: %s, maxVersion: %s",
+                        element, usedVersion.toString(), annotation.min(), annotation.max()));
             }
-            return disabled(format(
-                    "%s is disabled as Mandrel version %s does not satisfy constraints: minVersion: %s, maxVersion: %s",
-                    element, usedVersion, annotation.min(), annotation.max()));
-        } catch (IOException | InterruptedException e) {
-            throw new RuntimeException("Unable to get Mandrel version.", e);
         }
+        return disabled(format(
+                "%s is disabled as Mandrel version %s does not satisfy constraints: minVersion: %s, maxVersion: %s",
+                element, usedVersion, annotation.min(), annotation.max()));
     }
 }

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/UsedVersion.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/UsedVersion.java
@@ -31,68 +31,122 @@ import java.util.regex.Pattern;
 import static org.graalvm.tests.integration.utils.Commands.BUILDER_IMAGE;
 import static org.graalvm.tests.integration.utils.Commands.CONTAINER_RUNTIME;
 import static org.graalvm.tests.integration.utils.Commands.getRunCommand;
-import static org.graalvm.tests.integration.utils.Commands.removeContainers;
 
 /**
+ * Lazy loads Mandrel version either from a container or from
+ * the local installation, being thread safe about it.
+ *
  * Supported `native-image --version' output:
+ * GraalVM 20.3.3 Java 11 (Java Version 11.0.12+6-jvmci-20.3-b20)
+ * GraalVM 21.1.0 Java 11 CE (Java Version 11.0.11+8-jvmci-21.1-b05)
+ * GraalVM 21.3.0 Java 11 CE (Java Version 11.0.13+7-jvmci-21.3-b05)
  * GraalVM Version 20.1.0.4.Final (Mandrel Distribution) (Java Version 11.0.10+9)
+ * GraalVM Version 20.3.3.0-0b1 (Mandrel Distribution) (Java Version 11.0.12+7-LTS)
  * native-image 21.1.0.0-Final (Mandrel Distribution) (Java Version 11.0.11+9)
+ * native-image 21.2.0.2-0b3 Mandrel Distribution (Java Version 11.0.13+8-LTS)
+ * native-image 21.3.0.0-Final Mandrel Distribution (Java Version 17.0.1+12)
  *
  * @author Michal Karm Babacek <karm@redhat.com>
  */
 public class UsedVersion {
-    private static Version version = null;
-    private static Version versionInContainer = null;
 
-    private static final Logger LOGGER = Logger.getLogger(UsedVersion.class.getName());
-
-    private static final Pattern versionPattern = Pattern.compile("(?:GraalVM|native-image)(?: Version)? ([^ ]*).*");
-
-    private static Version versionParse(String version) {
-        // Invalid version string '20.1.0.4.Final'
-        return Version.parse(version
-                .toLowerCase()
-                .replace(".f", "-f")
-                .replace(".s", "-s"));
+    public static Version getVersion(boolean inContainer) {
+        return inContainer ? InContainer.mVersion.version : Locally.mVersion.version;
     }
 
-    public static Version getVersion(boolean inContainer) throws IOException, InterruptedException {
-        if (inContainer) {
-            if (versionInContainer == null) {
+    public static boolean jdkUsesSysLibs(boolean inContainer) {
+        return inContainer ? InContainer.mVersion.jdkUsesSysLibs : Locally.mVersion.jdkUsesSysLibs;
+    }
+
+    public static int jdkFeature(boolean inContainer) {
+        return inContainer ? InContainer.mVersion.jdkFeature : Locally.mVersion.jdkFeature;
+    }
+
+    public static int jdkInterim(boolean inContainer) {
+        return inContainer ? InContainer.mVersion.jdkInterim : Locally.mVersion.jdkInterim;
+    }
+
+    public static int jdkUpdate(boolean inContainer) {
+        return inContainer ? InContainer.mVersion.jdkUpdate : Locally.mVersion.jdkUpdate;
+    }
+
+    /**
+     * Mandrel Version plus additional metadata, e.g. jdkUsesSysLibs
+     */
+    private static final class MVersion {
+        private static final Logger LOGGER = Logger.getLogger(MVersion.class.getName());
+        private static final Pattern VERSION_PATTERN =
+                Pattern.compile("(?:GraalVM|native-image)(?: Version)? ([^ ]*).*Java Version ([\\d]+)\\.([\\d]+)\\.([\\d]+).*");
+
+        private final Version version;
+        private final boolean jdkUsesSysLibs;
+        private final int jdkFeature;
+        private final int jdkInterim;
+        private final int jdkUpdate;
+
+        public MVersion(boolean inContainer) {
+            final String lastLine;
+            if (inContainer) {
                 final List<String> cmd = List.of(CONTAINER_RUNTIME, "run", "-t", BUILDER_IMAGE, "native-image", "--version");
                 LOGGER.info("Running command " + cmd + " to determine Mandrel version used.");
-                final String out = Commands.runCommand(cmd);
-                final String[] lines = out.split(System.lineSeparator());
-                final String lastLine = lines[lines.length - 1].trim();
-                if (!lastLine.contains("Mandrel")) {
-                    LOGGER.warn("You are probably running GraalVM and not Mandrel container. " +
-                            "It might not work as tests might expect certain paths such as /opt/mandrel/.");
+                final String out;
+                try {
+                    out = Commands.runCommand(cmd);
+                } catch (IOException e) {
+                    throw new RuntimeException("Is " + CONTAINER_RUNTIME + " running?", e);
                 }
-                final Matcher m = versionPattern.matcher(lastLine);
-                if (!m.matches()) {
+                final String[] lines = out.split(System.lineSeparator());
+                lastLine = lines[lines.length - 1].trim();
+            } else {
+                final List<String> cmd = getRunCommand("native-image", "--version");
+                LOGGER.info("Running command " + cmd + " to determine Mandrel version used.");
+                try {
+                    lastLine = Commands.runCommand(cmd).trim();
+                } catch (IOException e) {
+                    throw new RuntimeException("Is native-image command available?", e);
+                }
+            }
+
+            jdkUsesSysLibs = lastLine.contains("-LTS");
+            if (inContainer && !lastLine.contains("Mandrel")) {
+                LOGGER.warn("You are probably running GraalVM and not Mandrel container. " +
+                        "It might not work as tests might expect certain paths such as /opt/mandrel/.");
+            }
+            final Matcher m = VERSION_PATTERN.matcher(lastLine);
+            if (!m.matches()) {
+                if (inContainer) {
                     throw new IllegalArgumentException("native-image command failed to produce a parseable output. " +
                             "Is " + CONTAINER_RUNTIME + " running and image " + BUILDER_IMAGE + " available? " +
                             "Output: '" + lastLine + "'");
+                } else {
+                    throw new IllegalArgumentException("native-image command failed to produce a parseable output. " +
+                            "Is it on PATH? " +
+                            "Output: '" + lastLine + "'");
                 }
-                versionInContainer = versionParse(m.group(1));
-                LOGGER.info("The test suite runs with Mandrel version " + versionInContainer + " in container.");
-            }
-            return versionInContainer;
-        }
-
-        if (version == null) {
-            final List<String> cmd = getRunCommand("native-image", "--version");
-            LOGGER.info("Running command " + cmd + " to determine Mandrel version used.");
-            final String line = Commands.runCommand(cmd).trim();
-            final Matcher m = versionPattern.matcher(line);
-            if (!m.matches()) {
-                throw new IllegalArgumentException("native-image command failed to produce a parseable output. " +
-                        "Is it on PATH? " +
-                        "Output: '" + line + "'");
             }
             version = versionParse(m.group(1));
-            LOGGER.info("The test suite runs with Mandrel version " + version + " installed locally on PATH.");
+            jdkFeature = Integer.parseInt(m.group(2));
+            jdkInterim = Integer.parseInt(m.group(3));
+            jdkUpdate = Integer.parseInt(m.group(4));
+            LOGGER.infof("The test suite runs with Mandrel version %s %s, JDK %d.%d.%d.",
+                    version.toString(), inContainer ? "in container" : " installed locally on PATH", jdkFeature, jdkInterim, jdkUpdate);
         }
-        return version;
+
+        private static Version versionParse(String version) {
+            // Invalid version string '20.1.0.4.Final'
+            return Version.parse(version
+                    .toLowerCase()
+                    .replace(".f", "-f")
+                    .replace(".s", "-s"));
+        }
     }
+
+    private static class InContainer {
+        private static final MVersion mVersion = new MVersion(true);
+    }
+
+    private static class Locally {
+        private static final MVersion mVersion = new MVersion(false);
+    }
+
 }


### PR DESCRIPTION
Gets rid of false positive on ImageIO test when using e.g. images from registry.access.redhat.com.