### PR TITLE
Ignore warning about --allow-incomplete-classpath in helidon quickstart

### DIFF
--- a/.github/workflows/builder_image_tests.yml
+++ b/.github/workflows/builder_image_tests.yml
@@ -64,7 +64,8 @@ jobs:
         env:
           MAVEN_OPTS: -Xmx1g
         run:   |
-          sudo apt install gdb
+          sudo apt-get update -y
+          sudo apt-get install -y gdb
           pushd ts
           mvn clean verify -Ptestsuite-builder-image -Dquarkus.version=${{ matrix.quarkus-version }} -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:${{ matrix.mandrel-builder-image }}
         shell: bash

--- a/.github/workflows/local_tests.yml
+++ b/.github/workflows/local_tests.yml
@@ -104,7 +104,8 @@ jobs:
         env:
           MAVEN_OPTS: -Xmx1g
         run:   |
-          sudo apt install gdb
+          sudo apt-get update -y
+          sudo apt-get install -y gdb
           export JAVA_HOME=${{ github.workspace }}/${{ matrix.mandrel-version }}
           export GRAALVM_HOME="${JAVA_HOME}"
           export PATH="${JAVA_HOME}/bin:$PATH"

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
@@ -115,7 +115,13 @@ public enum WhitelistLogLines {
 
     HELIDON_QUICKSTART_SE(new Pattern[]{
             // Unused argument on new Graal
-            Pattern.compile(".*Ignoring server-mode native-image argument --no-server.*")
+            Pattern.compile(".*Ignoring server-mode native-image argument --no-server.*"),
+            // --allow-incomplete-classpath not available in new GraalVM https://github.com/Karm/mandrel-integration-tests/issues/76
+            Pattern.compile(".*Using a deprecated option --allow-incomplete-classpath from " +
+                    "jar:file:.*mandrel-integration-tests/apps/helidon-quickstart-se/target/libs/helidon-webserver-2.2.2.jar" +
+                    "!/META-INF/native-image/io.helidon.webserver/helidon-webserver/native-image.properties. " +
+                    "Allowing an incomplete classpath is now the default. " +
+                    "Use --link-at-build-time to report linking errors at image build time for a class or package.*")
     }),
 
     QUARKUS_BUILDER_IMAGE_ENCODING(new Pattern[]{


### PR DESCRIPTION
`--allow-incomplete-classpath` will not be available starting from GraalVM/Mandrel 22.1

Fixes #76