### PR TITLE
Adds minJDK and maxJDK to IfMandrelVersion annotation

### DIFF
--- a/.github/workflows/builder_image_tests.yml
+++ b/.github/workflows/builder_image_tests.yml
@@ -84,6 +84,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y gdb
           pushd ts
+          mkdir -p ~/.m2/
           cp .github/mvn-settings.xml ~/.m2/settings.xml
           mvn clean verify -Ptestsuite-builder-image -Dquarkus.version=${{ matrix.quarkus-version }} -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:${{ matrix.mandrel-builder-image }}
         shell: bash

--- a/.github/workflows/testing_testsuite.yml
+++ b/.github/workflows/testing_testsuite.yml
@@ -1,4 +1,4 @@
-name: Mandrel Locally
+name: Testing testsuite
 
 on:
   workflow_dispatch:
@@ -14,71 +14,17 @@ on:
 
 env:
   LANG: en_US.UTF-8
-  FAIL_ON_PERF_REGRESSION: false
 
 jobs:
   local-run:
-    name: ${{ matrix.os }} - ${{ matrix.java-version }} - ${{ matrix.mandrel-version }} - ${{ matrix.quarkus-version }}
+    name: ${{ matrix.os }} - ${{ matrix.java-version }} - ${{ matrix.mandrel-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        quarkus-version: [ '1.11.7.Final', '2.5.4.Final', '2.7.5.Final' ]
-        mandrel-version: [ '20.3.3.0-Final', '21.2.0.2-Final', '21.3.1.1-Final', '22.0.0.2-Final' ]
+        mandrel-version: [ '21.3.1.1-Final', '22.0.0.2-Final' ]
         java-version: [ '11', '17' ]
         os: [ ubuntu-20.04, windows-2019 ]
-        exclude:
-          - quarkus-version: '1.11.7.Final'
-            mandrel-version: '20.3.3.0-Final'
-            java-version: '17'
-          - quarkus-version: '1.11.7.Final'
-            mandrel-version: '21.2.0.2-Final'
-            java-version: '11'
-          - quarkus-version: '1.11.7.Final'
-            mandrel-version: '21.2.0.2-Final'
-            java-version: '17'
-          - quarkus-version: '1.11.7.Final'
-            mandrel-version: '21.3.1.1-Final'
-            java-version: '11'
-          - quarkus-version: '1.11.7.Final'
-            mandrel-version: '21.3.1.1-Final'
-            java-version: '17'
-          - quarkus-version: '1.11.7.Final'
-            mandrel-version: '22.0.0.2-Final'
-            java-version: '11'
-          - quarkus-version: '1.11.7.Final'
-            mandrel-version: '22.0.0.2-Final'
-            java-version: '17'
-          - quarkus-version: '2.5.4.Final'
-            mandrel-version: '20.3.3.0-Final'
-            java-version: '11'
-          - quarkus-version: '2.5.4.Final'
-            mandrel-version: '20.3.3.0-Final'
-            java-version: '17'
-          - quarkus-version: '2.5.4.Final'
-            mandrel-version: '22.0.0.2-Final'
-            java-version: '11'
-          - quarkus-version: '2.5.4.Final'
-            mandrel-version: '22.0.0.2-Final'
-            java-version: '17'
-          - quarkus-version: '2.5.4.Final'
-            mandrel-version: '21.2.0.2-Final'
-            java-version: '17'
-          - quarkus-version: '2.5.4.Final'
-            mandrel-version: '21.3.1.1-Final'
-            java-version: '17'
-          - quarkus-version: '2.7.5.Final'
-            mandrel-version: '20.3.3.0-Final'
-            java-version: '11'
-          - quarkus-version: '2.7.5.Final'
-            mandrel-version: '20.3.3.0-Final'
-            java-version: '17'
-          - quarkus-version: '2.7.5.Final'
-            mandrel-version: '21.2.0.2-Final'
-            java-version: '11'
-          - quarkus-version: '2.7.5.Final'
-            mandrel-version: '21.2.0.2-Final'
-            java-version: '17'
     steps:
       - uses: actions/checkout@v2
         with:
@@ -88,9 +34,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: ${{ matrix.quarkus-version }}-${{ matrix.os }}-${{ hashFiles('**/pom.xml') }}
+          key: ${{ matrix.os }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ matrix.quarkus-version }}-${{ matrix.os }}-
+            ${{ matrix.os }}-
       - uses: actions/cache@v2
         name: Mandrel installation cached
         id: cache_mandrel
@@ -138,9 +84,9 @@ jobs:
             cmd /C native-image --version
           )
           pushd ts
-          mkdir ~/.m2
+          mkdir ~/.m2/
           copy .github/mvn-settings.xml ~/.m2/settings.xml
-          mvn clean verify -Ptestsuite -Dquarkus.version=${{ matrix.quarkus-version }}
+          mvn clean verify -Ptestsuite -DexcludeTags=all -DincludeTags=testing-testsuite
         shell: cmd
       - name: Linux test
         if: startsWith(matrix.os, 'ubuntu')
@@ -161,7 +107,7 @@ jobs:
           pushd ts
           mkdir -p ~/.m2/
           cp .github/mvn-settings.xml ~/.m2/settings.xml
-          mvn clean verify -Ptestsuite -Dquarkus.version=${{ matrix.quarkus-version }}
+          mvn clean verify -Ptestsuite -DexcludeTags=all -DincludeTags=testing-testsuite
         shell: bash
       - name: Prepare failure archive (if maven failed)
         if: failure()
@@ -170,5 +116,5 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: reports-${{ matrix.mandrel-version }}-${{ matrix.java-version }}-${{ matrix.quarkus-version }}-${{ matrix.os }}
+          name: reports-${{ matrix.mandrel-version }}-${{ matrix.java-version }}-${{ matrix.os }}
           path: 'test-reports-mandrel-it.tgz'

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.graalvm.sdk</groupId>
             <artifactId>graal-sdk</artifactId>
-            <version>21.2.0</version>
+            <version>21.3.1</version>
         </dependency>
 
         <dependency>

--- a/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
@@ -30,9 +30,7 @@ import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
-import org.junit.jupiter.api.condition.DisabledOnJre;
 import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.condition.OS;
 
 import java.io.File;
@@ -572,8 +570,7 @@ public class AppReproducersTest {
     @Test
     @Tag("jdk-17")
     @Tag("recordannotations")
-    @DisabledOnJre(JRE.JAVA_11)
-    @IfMandrelVersion(min = "21.3.1.1")
+    @IfMandrelVersion(min = "21.3.1.1", minJDK = "17")
     public void recordAnnotationsWork(TestInfo testInfo) throws IOException, InterruptedException {
         final Apps app = Apps.RECORDANNOTATIONS;
         LOGGER.info("Testing app: " + app);

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/IfMandrelVersion.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/IfMandrelVersion.java
@@ -40,12 +40,24 @@ import java.lang.annotation.Target;
  *
  *     IfMandrelVersion(min = "21.1", inContainer = true)
  *     i.e. [21.1, +∞)
+ *
+ *     IfMandrelVersion(min = "21.3.1", minJDK = "17")
+ *     i.e. [21.3.1, +∞) and [17, +∞)
+ *
+ *     IfMandrelVersion(min = "22", minJDK = "17", maxJDK = "17.0.2")
+ *     i.e. [22, +∞) and [17, 17.0.2]
+ *
  * //@formatter:on
  * Note that versions 21.1.0.0-final and 21.1.0.0-snapshot and 21.1.0.0 are all considered equal.
  *
  * The actual comparator comes from Graal's own org.graalvm.home.Version.
  *
  * inContainer: Whether the version should be pulled from a builder image container.
+ *
+ * JDK versions comparator uses feature.interim.update, the fourth, patch number or
+ * any other qualifiers following that are not used, i.e.
+ * 17.0.3-beta+5-202203292328 and 17.0.3-beta+6 are the same and
+ * 11.0.14.1+1-LTS and 11.0.14 are the same.
  *
  * @author Michal Karm Babacek <karm@redhat.com>
  */
@@ -57,6 +69,10 @@ public @interface IfMandrelVersion {
     String min() default "";
 
     String max() default "";
+
+    String minJDK() default "";
+
+    String maxJDK() default "";
 
     boolean inContainer() default false;
 }

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/MandrelVersionCondition.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/MandrelVersionCondition.java
@@ -25,8 +25,11 @@ import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.lang.reflect.AnnotatedElement;
+import java.util.regex.Pattern;
 
 import static java.lang.String.format;
+import static org.graalvm.tests.integration.utils.versions.UsedVersion.compareJDKVersion;
+import static org.graalvm.tests.integration.utils.versions.UsedVersion.featureInterimUpdate;
 import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
 import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
 import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
@@ -52,15 +55,28 @@ public class MandrelVersionCondition implements ExecutionCondition {
 
     private ConditionEvaluationResult disableIfVersionMismatch(IfMandrelVersion annotation, AnnotatedElement element) {
         final Version usedVersion = UsedVersion.getVersion(annotation.inContainer());
-        if (annotation.min().isBlank() || usedVersion.compareTo(Version.parse(annotation.min())) >= 0) {
-            if (annotation.max().isBlank() || usedVersion.compareTo(Version.parse(annotation.max())) <= 0) {
-                return enabled(format(
-                        "%s is enabled as Mandrel version %s does satisfy constraints: minVersion: %s, maxVersion: %s",
-                        element, usedVersion.toString(), annotation.min(), annotation.max()));
-            }
+        boolean jdkConstraintSatisfied = true;
+        if (!annotation.minJDK().isBlank() || !annotation.maxJDK().isBlank()) {
+            final int[] jdkVersion = new int[]{
+                    UsedVersion.jdkFeature(annotation.inContainer()),
+                    UsedVersion.jdkInterim(annotation.inContainer()),
+                    UsedVersion.jdkUpdate(annotation.inContainer())
+            };
+            final Pattern p = Pattern.compile("(?<jfeature>[0-9]+)(\\.(?<jinterim>[0-9]*)\\.(?<jupdate>[0-9]*))?");
+            final int[] min = featureInterimUpdate(p, annotation.minJDK(), Integer.MIN_VALUE);
+            final int[] max = featureInterimUpdate(p, annotation.maxJDK(), Integer.MAX_VALUE);
+            jdkConstraintSatisfied = compareJDKVersion(jdkVersion, min) >= 0 && compareJDKVersion(jdkVersion, max) <= 0;
+        }
+        final boolean mandrelConstraintSatisfied =
+                (annotation.min().isBlank() || usedVersion.compareTo(Version.parse(annotation.min())) >= 0) &&
+                        (annotation.max().isBlank() || usedVersion.compareTo(Version.parse(annotation.max())) <= 0);
+        if (mandrelConstraintSatisfied && jdkConstraintSatisfied) {
+            return enabled(format(
+                    "%s is enabled as Mandrel version %s does satisfy constraints: min: %s, max: %s, minJDK: %s, maxJDK: %s",
+                    element, usedVersion.toString(), annotation.min(), annotation.max(), annotation.minJDK(), annotation.maxJDK()));
         }
         return disabled(format(
-                "%s is disabled as Mandrel version %s does not satisfy constraints: minVersion: %s, maxVersion: %s",
-                element, usedVersion, annotation.min(), annotation.max()));
+                "%s is disabled as Mandrel version %s does not satisfy constraints: min: %s, max: %s, minJDK: %s, maxJDK: %s",
+                element, usedVersion, annotation.min(), annotation.max(), annotation.minJDK(), annotation.maxJDK()));
     }
 }

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/QuarkusVersion.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/QuarkusVersion.java
@@ -25,7 +25,7 @@ public class QuarkusVersion implements Comparable<QuarkusVersion> {
     private final int major;
     private final int minor;
     private final int patch;
-    private boolean snapshot;
+    private final boolean snapshot;
 
     public QuarkusVersion(String version) {
         this.version = version;

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/VersionsTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/VersionsTest.java
@@ -1,0 +1,155 @@
+package org.graalvm.tests.integration.utils.versions;
+/*
+ * Copyright (c) 2022, Red Hat Inc. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import org.graalvm.tests.integration.utils.Logs;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermissions;
+
+import static org.graalvm.tests.integration.utils.Commands.IS_THIS_WINDOWS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Testing test suite...
+ *
+ * A fake native-image executable script is created, it contains a single version string.
+ * Using the property FAKE_NATIVE_IMAGE_DIR, the test suite is tricked into running it
+ * during native-image version resolution.
+ * A series of test methods is executed by JUnit, business as usual. Those test methods log
+ * their executing into a file.
+ * After all tests are done, the file is examined. If it contains any superfluous entries
+ * or if it's missing anything, the test lass fails.
+ */
+@Tag("testing-testsuite")
+public class VersionsTest {
+    static final Path NATIVE_IMAGE = Path.of(System.getProperty("java.io.tmpdir"), IS_THIS_WINDOWS ? "native-image.cmd" : "native-image");
+    static final String VERSION = "native-image 22.2.0-devdb26f5c4fbe Mandrel Distribution (Java Version 17.0.3-beta+5-202203292328)";
+    static final Path LOG = Path.of(System.getProperty("java.io.tmpdir"), "versions-log");
+    static final StandardOpenOption[] LOG_FILE_OPS = new StandardOpenOption[]{StandardOpenOption.CREATE, StandardOpenOption.APPEND, StandardOpenOption.WRITE};
+
+    @BeforeAll
+    public static void setup() throws IOException {
+        System.setProperty("FAKE_NATIVE_IMAGE_DIR", System.getProperty("java.io.tmpdir") + File.separator);
+        Files.writeString(NATIVE_IMAGE, IS_THIS_WINDOWS ?
+                        "@echo off" + System.lineSeparator() +
+                                "echo " + VERSION + System.lineSeparator() :
+                        "#!/bin/sh" + System.lineSeparator() +
+                                "echo '" + VERSION + "'" + System.lineSeparator(),
+                StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
+        if (!IS_THIS_WINDOWS) {
+            Files.setPosixFilePermissions(NATIVE_IMAGE, PosixFilePermissions.fromString("rwxr-xr-x"));
+        }
+        Files.deleteIfExists(LOG);
+    }
+
+    @AfterAll
+    public static void teardown() throws IOException {
+        System.clearProperty("FAKE_NATIVE_IMAGE_DIR");
+        Files.deleteIfExists(NATIVE_IMAGE);
+        final String testlog = Files.readString(LOG, StandardCharsets.UTF_8);
+        try {
+            assertEquals(
+                    "Running test jdkVersionCheckA\n" +
+                            "Running test jdkVersionCheckB\n" +
+                            "Running test jdkVersionCheckC\n" +
+                            "Running test jdkVersionCheckD\n" +
+                            "Running test jdkVersionCheckI\n", testlog);
+        } finally {
+            Logs.archiveLog(VersionsTest.class.getCanonicalName(), "versionTest", LOG.toFile());
+            Files.deleteIfExists(LOG);
+        }
+    }
+
+    @Test
+    @Order(1)
+    @IfMandrelVersion(min = "21.3.1")
+    public void jdkVersionCheckA(TestInfo testInfo) throws IOException {
+        Files.writeString(LOG, "Running test " + testInfo.getTestMethod().get().getName() + "\n", StandardCharsets.UTF_8, LOG_FILE_OPS);
+    }
+
+    @Test
+    @Order(2)
+    @IfMandrelVersion(min = "21.3.1", minJDK = "17")
+    public void jdkVersionCheckB(TestInfo testInfo) throws IOException {
+        Files.writeString(LOG, "Running test " + testInfo.getTestMethod().get().getName() + "\n", StandardCharsets.UTF_8, LOG_FILE_OPS);
+    }
+
+    @Test
+    @Order(3)
+    @IfMandrelVersion(min = "22", minJDK = "17")
+    public void jdkVersionCheckC(TestInfo testInfo) throws IOException {
+        Files.writeString(LOG, "Running test " + testInfo.getTestMethod().get().getName() + "\n", StandardCharsets.UTF_8, LOG_FILE_OPS);
+    }
+
+    @Test
+    @Order(4)
+    @IfMandrelVersion(min = "22", minJDK = "17.0.2")
+    public void jdkVersionCheckD(TestInfo testInfo) throws IOException {
+        Files.writeString(LOG, "Running test " + testInfo.getTestMethod().get().getName() + "\n", StandardCharsets.UTF_8, LOG_FILE_OPS);
+    }
+
+    @Test
+    @Order(5)
+    @IfMandrelVersion(min = "22", minJDK = "17", maxJDK = "17.0.2")
+    public void jdkVersionCheckE(TestInfo testInfo) throws IOException {
+        Files.writeString(LOG, "Running test " + testInfo.getTestMethod().get().getName() + "\n", StandardCharsets.UTF_8, LOG_FILE_OPS);
+    }
+
+    @Test
+    @Order(6)
+    @IfMandrelVersion(min = "21", minJDK = "11.0.12", maxJDK = "17.0.1")
+    public void jdkVersionCheckF(TestInfo testInfo) throws IOException {
+        Files.writeString(LOG, "Running test " + testInfo.getTestMethod().get().getName() + "\n", StandardCharsets.UTF_8, LOG_FILE_OPS);
+    }
+
+    @Test
+    @Order(7)
+    @IfMandrelVersion(min = "21", maxJDK = "11")
+    public void jdkVersionCheckG(TestInfo testInfo) throws IOException {
+        Files.writeString(LOG, "Running test " + testInfo.getTestMethod().get().getName() + "\n", StandardCharsets.UTF_8, LOG_FILE_OPS);
+    }
+
+    @Test
+    @Order(8)
+    @IfMandrelVersion(min = "21.2", minJDK = "18.0.0")
+    public void jdkVersionCheckH(TestInfo testInfo) throws IOException {
+        Files.writeString(LOG, "Running test " + testInfo.getTestMethod().get().getName() + "\n", StandardCharsets.UTF_8, LOG_FILE_OPS);
+    }
+
+    @Test
+    @Order(9)
+    @IfMandrelVersion(min = "22", max = "22.2", minJDK = "17.0.1", maxJDK = "17.0.3")
+    public void jdkVersionCheckI(TestInfo testInfo) throws IOException {
+        Files.writeString(LOG, "Running test " + testInfo.getTestMethod().get().getName() + "\n", StandardCharsets.UTF_8, LOG_FILE_OPS);
+    }
+
+}


### PR DESCRIPTION
Tested examples:

```java
    @Test
    @Tag("jdkVersionTest")
    @Order(1)
    @IfMandrelVersion(min = "21.3.1")
    public void jdkVersionCheckA(TestInfo testInfo) {
        System.out.println("KARM Running test "+testInfo.getTestMethod());
    }

    @Test
    @Tag("jdkVersionTest")
    @Order(2)
    @IfMandrelVersion(min = "21.3.1", minJDK = "17")
    public void jdkVersionCheckB(TestInfo testInfo) {
        System.out.println("KARM Running test "+testInfo.getTestMethod());
    }

    @Test
    @Tag("jdkVersionTest")
    @Order(3)
    @IfMandrelVersion(min = "22", minJDK = "17")
    public void jdkVersionCheckC(TestInfo testInfo) {
        System.out.println("KARM Running test "+testInfo.getTestMethod());
    }

    @Test
    @Tag("jdkVersionTest")
    @Order(4)
    @IfMandrelVersion(min = "22", minJDK = "17.0.2")
    public void jdkVersionCheckD(TestInfo testInfo) {
        System.out.println("KARM Running test "+testInfo.getTestMethod());
    }

    @Test
    @Tag("jdkVersionTest")
    @Order(5)
    @IfMandrelVersion(min = "22", minJDK = "17", maxJDK = "17.0.2")
    public void jdkVersionCheckE(TestInfo testInfo) {
        System.out.println("KARM Running test "+testInfo.getTestMethod());
    }

    @Test
    @Tag("jdkVersionTest")
    @Order(6)
    @IfMandrelVersion(min = "21", minJDK = "11.0.12", maxJDK = "17.0.1")
    public void jdkVersionCheckF(TestInfo testInfo) {
        System.out.println("KARM Running test "+testInfo.getTestMethod());
    }

    @Test
    @Tag("jdkVersionTest")
    @Order(7)
    @IfMandrelVersion(min = "21", maxJDK = "11")
    public void jdkVersionCheckG(TestInfo testInfo) {
        System.out.println("KARM Running test "+testInfo.getTestMethod());
    }
```