### PR TITLE
Fix resources tests for 22.1

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
@@ -196,7 +196,7 @@ public class AppReproducersTest {
 
     @Test
     @Tag("resources")
-    @IfMandrelVersion(min = "22.0", max = "22.1")
+    @IfMandrelVersion(min = "22.0", max = "22.0")
     public void resLocationsB(TestInfo testInfo) throws IOException, InterruptedException {
         final String expectedOutput = "" +
                 "Resources folders:\n" +
@@ -251,7 +251,7 @@ public class AppReproducersTest {
 
     @Test
     @Tag("resources")
-    @IfMandrelVersion(min = "22.2")
+    @IfMandrelVersion(min = "22.1")
     public void resLocationsC(TestInfo testInfo) throws IOException, InterruptedException {
         final String expectedOutput = "" +
                 "Resources folders:\n" +


### PR DESCRIPTION
The resources fix https://github.com/oracle/graal/commit/7c4257f3f88d7cf2a368b92c714b8d55b44f36cd
is backported to 22.1 as well