### PR TITLE
Update warning pattern for --allow-incomplete-classpath

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
@@ -117,9 +117,8 @@ public enum WhitelistLogLines {
             // Unused argument on new Graal
             Pattern.compile(".*Ignoring server-mode native-image argument --no-server.*"),
             // --allow-incomplete-classpath not available in new GraalVM https://github.com/Karm/mandrel-integration-tests/issues/76
-            Pattern.compile(".*Using a deprecated option --allow-incomplete-classpath from " +
-                    "jar:file:.*mandrel-integration-tests/apps/helidon-quickstart-se/target/libs/helidon-webserver-2.2.2.jar" +
-                    "!/META-INF/native-image/io.helidon.webserver/helidon-webserver/native-image.properties. " +
+            Pattern.compile(".*Using a deprecated option --allow-incomplete-classpath from" +
+                    ".*helidon-webserver-2.2.2.jar.*" +
                     "Allowing an incomplete classpath is now the default. " +
                     "Use --link-at-build-time to report linking errors at image build time for a class or package.*")
     }),


### PR DESCRIPTION
Warning changed from:

"... from 'jar:file:///path/to/helidon-webserver-2.2.2.jar!/META-INF/native-image/io.helidon.webserver/helidon-webserver/native-image.properties' ... "

to:

"... from 'META-INF/native-image/io.helidon.webserver/helidon-webserver/native-image.properties' in 'jar:file:///path/to/helidon-webserver-2.2.2.jar'"