### PR TITLE
Disable recordAnnotationsWork test on 22.0

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
@@ -574,7 +574,19 @@ public class AppReproducersTest {
     @Test
     @Tag("jdk-17")
     @Tag("recordannotations")
-    @IfMandrelVersion(min = "21.3.1.1", minJDK = "17")
+    @IfMandrelVersion(min = "21.3.1.1", max = "21.3.999", minJDK = "17")
+    public void recordAnnotationsWork21_3(TestInfo testInfo) throws IOException, InterruptedException {
+        recordAnnotationsWork(testInfo);
+    }
+
+    @Test
+    @Tag("jdk-17")
+    @Tag("recordannotations")
+    @IfMandrelVersion(min = "22.1", minJDK = "17")
+    public void recordAnnotationsWorkPost22_1(TestInfo testInfo) throws IOException, InterruptedException {
+        recordAnnotationsWork(testInfo);
+    }
+
     public void recordAnnotationsWork(TestInfo testInfo) throws IOException, InterruptedException {
         final Apps app = Apps.RECORDANNOTATIONS;
         LOGGER.info("Testing app: " + app);


### PR DESCRIPTION
The fix for record annotations will be part of 22.1 and is backported to 21.3.1.1 but it's not present in 22.0