### PR TITLE
[WIP] Reports build perf of a Q app to https://github.com/Karm/collector

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/PerfCheckTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/PerfCheckTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.graalvm.tests.integration;
+
+import com.sun.management.OperatingSystemMXBean;
+import org.graalvm.tests.integration.utils.Commands;
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
+import static org.graalvm.tests.integration.utils.BuildLogParser.mapToJSON;
+import static org.graalvm.tests.integration.utils.BuildLogParser.parse;
+import static org.graalvm.tests.integration.utils.Commands.QUARKUS_VERSION;
+import static org.graalvm.tests.integration.utils.Commands.getProperty;
+import static org.graalvm.tests.integration.utils.Commands.processStopper;
+import static org.graalvm.tests.integration.utils.Commands.runCommand;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * @author Michal Karm Babacek <karm@redhat.com>
+ */
+@Tag("perfcheck")
+public class PerfCheckTest {
+
+    private static final Logger LOGGER = Logger.getLogger(PerfCheckTest.class.getName());
+
+    @Test
+    public void buildAndReport(TestInfo testInfo) throws IOException, InterruptedException {
+        final String appDir = Commands.getProperty("perf.app.dir");
+        assertNotNull(appDir, "We cannot continue without having the PERF_APP_DIR set.");
+        final Map<String, String> report = new TreeMap<>();
+        report.put("arch", getProperty("perf.app.arch", ""));
+        report.put("os", getProperty("perf.app.os", ""));
+        report.put("nativeImageXmXMB", getProperty("perf.app.xmxmb", "0"));
+        report.put("quarkusVersion", QUARKUS_VERSION.getVersionString());
+        report.put("ramAvailableMB", Long.toString(
+                ((OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean()).getFreePhysicalMemorySize()
+                        / 1024 / 1024));
+        report.put("runnerDescription",
+                getProperty("perf.app.runner.description", ""));
+        report.put("testApp", getProperty("perf.app.url", ""));
+        LOGGER.info("Testing app: " + appDir);
+        Process process = null;
+        final File processLog = new File(appDir, "build-and-run.log");
+        Files.deleteIfExists(processLog.toPath());
+        try {
+            final List<String> cmd = Commands.getRunCommand(
+                    "./mvnw",
+                    "clean",
+                    "package",
+                    "-Pnative",
+                    "-Dquarkus.native.native-image-xmx=" + report.get("nativeImageXmXMB") + "M",
+                    "-Dquarkus.platform.version=" + report.get("quarkusVersion"),
+                    "-Dmaven.compiler.release=11");
+            process = runCommand(cmd, new File(appDir), processLog, null);
+            process.waitFor(60, TimeUnit.MINUTES);
+
+            report.putAll(parse(processLog.toPath()));
+
+            final Path pathToNormalize = Path.of(report.remove("executablePath"));
+            final Path executable = Path.of(pathToNormalize.getParent().getParent().toString(),
+                    pathToNormalize.getFileName().toString());
+            if (Files.notExists(executable) || Files.size(executable) < 1024 * 1024) {
+                throw new IllegalArgumentException(
+                        "Something is wrong, the executable from the log dos not exist or is way too small. Check "
+                                + executable);
+            }
+            report.put("executableSizeMB", Long.toString(Files.size(executable) / 1024 / 1024));
+
+            final String payload = mapToJSON(report);
+            LOGGER.info(payload);
+            final String[] headers = new String[] {
+                    "User-Agent", "Mandrel Integration TS",
+                    "token", Commands.getProperty("perf.app.secret.token"),
+                    "Content-Type", "application/json",
+                    "Accept", "text/plain"
+            };
+            final HttpRequest releaseRequest = HttpRequest.newBuilder()
+                    .method("POST", HttpRequest.BodyPublishers.ofString(payload))
+                    .uri(new URI(Commands.getProperty("perf.app.endpoint")))
+                    .headers(headers)
+                    .build();
+            final HttpClient hc = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.ALWAYS).build();
+            final HttpResponse<String> releaseResponse = hc.send(releaseRequest, HttpResponse.BodyHandlers.ofString());
+            LOGGER.info("Response Code : " + releaseResponse.statusCode());
+            LOGGER.info("Response Body : " + releaseResponse.body());
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+        } finally {
+            if (process != null) {
+                processStopper(process, false);
+            }
+        }
+    }
+}

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildLogParser.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildLogParser.java
@@ -1,0 +1,139 @@
+package org.graalvm.tests.integration.utils;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Quarkus specific due to version parsing
+ */
+public class BuildLogParser {
+
+    public enum Attributes {
+        NATIVE_IMAGE_VERSION(Pattern.compile(
+                ".*Running Quarkus.*(?:GraalVM|native-image)(?: Version)? (?<mversion>[^ ]*).*Java Version (?<jversion>[^)]+).*")),
+        CLASSES_REACHABLE(Pattern.compile(
+                "\\s+(?<reachable>[\\d,]+)\\s+\\(.*%\\)\\s+of\\s+(?<classes>[\\d,]+)\\s+classes reachable.*")),
+        FIELDS_REACHABLE(Pattern.compile(
+                "\\s+(?<reachable>[\\d,]+)\\s+\\(.*%\\)\\s+of\\s+(?<fields>[\\d,]+)\\s+fields reachable.*")),
+        METHODS_REACHABLE(Pattern.compile(
+                "\\s+(?<reachable>[\\d,]+)\\s+\\(.*%\\)\\s+of\\s+(?<methods>[\\d,]+)\\s+methods reachable.*")),
+        REFLECTION(Pattern.compile(
+                "\\s+(?<classes>[\\d,]+)\\s+classes,\\s+(?<fields>[\\d,]+)\\s+fields, and\\s+(?<methods>[\\d,]+)\\s+methods registered for reflection.*")),
+        JNI(Pattern.compile(
+                "\\s+(?<classes>[\\d,]+)\\s+classes,\\s+(?<fields>[\\d,]+)\\s+fields, and\\s+(?<methods>[\\d,]+)\\s+methods registered for JNI access.*")),
+        GC_RSS_STATS(Pattern.compile(
+                "\\s+(?<time>[\\d\\.]+)(?<timeunit>[^ ]+)\\s+\\(.* of total time\\) in\\s+(?<gcs>\\d+) GCs \\| Peak RSS: (?<rss>[\\d\\.]+)(?<rssunit>[^ ]+) \\| CPU load:.*")),
+        BUILD_TIME(Pattern.compile(
+                ".*Finished generating .* in (?<minutes>\\d+)m (?<seconds>\\d+)s.*")),
+        EXECUTABLE(Pattern.compile("\\s+(?<path>[^ ]+) \\(executable\\)$"));
+        public final Pattern pattern;
+
+        Attributes(Pattern pattern) {
+            this.pattern = pattern;
+        }
+    }
+
+    public static Map<String, String> parse(Path buildLog) throws IOException {
+        final Map<String, String> data = new TreeMap<>();
+        try (Scanner sc = new Scanner(buildLog, UTF_8)) {
+            while (sc.hasNextLine()) {
+                final String line = sc.nextLine();
+                Matcher m = Attributes.NATIVE_IMAGE_VERSION.pattern.matcher(line);
+                if (m.matches()) {
+                    data.put("mandrelVersion", m.group("mversion"));
+                    data.put("jdkVersion", m.group("jversion"));
+                    continue;
+                }
+                m = Attributes.CLASSES_REACHABLE.pattern.matcher(line);
+                if (m.matches()) {
+                    data.put("classesReachable", m.group("reachable").replace(",", ""));
+                    data.put("classes", m.group("classes").replace(",", ""));
+                    continue;
+                }
+                m = Attributes.FIELDS_REACHABLE.pattern.matcher(line);
+                if (m.matches()) {
+                    data.put("fieldsReachable", m.group("reachable").replace(",", ""));
+                    data.put("fields", m.group("fields").replace(",", ""));
+                    continue;
+                }
+                m = Attributes.METHODS_REACHABLE.pattern.matcher(line);
+                if (m.matches()) {
+                    data.put("methodsReachable", m.group("reachable").replace(",", ""));
+                    data.put("methods", m.group("methods").replace(",", ""));
+                    continue;
+                }
+                m = Attributes.REFLECTION.pattern.matcher(line);
+                if (m.matches()) {
+                    data.put("methodsForReflection", m.group("methods").replace(",", ""));
+                    data.put("fieldsForReflection", m.group("fields").replace(",", ""));
+                    data.put("classesForReflection", m.group("classes").replace(",", ""));
+                    continue;
+                }
+                m = Attributes.JNI.pattern.matcher(line);
+                if (m.matches()) {
+                    data.put("methodsForJNIAccess", m.group("methods").replace(",", ""));
+                    data.put("fieldsForJNIAccess", m.group("fields").replace(",", ""));
+                    data.put("classesForJNIAccess", m.group("classes").replace(",", ""));
+                    continue;
+                }
+                m = Attributes.GC_RSS_STATS.pattern.matcher(line);
+                if (m.matches()) {
+                    if ("s".equalsIgnoreCase(m.group("timeunit"))) {
+                        data.put("timeInGCS", Long.toString(Math.round(Double.parseDouble(m.group("time")))));
+                    } else {
+                        throw new IllegalArgumentException("Unexpected unit `" + m.group("timeunit") + "'. Fix the parser.");
+                    }
+                    data.put("numberOfGC", m.group("gcs"));
+                    if ("GB".equalsIgnoreCase(m.group("rssunit"))) {
+                        data.put("peakRSSMB", Long.toString(Math.round(Double.parseDouble(m.group("rss")) * 1024)));
+                    } else {
+                        throw new IllegalArgumentException("Unexpected unit `" + m.group("rssunit") + "'. Fix the parser.");
+                    }
+                    continue;
+                }
+                m = Attributes.BUILD_TIME.pattern.matcher(line);
+                if (m.matches()) {
+                    int minutes = Integer.parseInt(m.group("minutes"));
+                    int seconds = Integer.parseInt(m.group("seconds"));
+                    data.put("buildTimeS", Integer.toString(minutes * 60 + seconds));
+                    continue;
+                }
+                m = Attributes.EXECUTABLE.pattern.matcher(line);
+                if (m.matches()) {
+                    data.put("executablePath", m.group("path"));
+                }
+            }
+        }
+        return data;
+    }
+
+    public static String mapToJSON(Map<String, String> map) {
+        final Pattern num = Pattern.compile("\\d+");
+        final StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        map.forEach((k, v) -> {
+            sb.append("\"");
+            sb.append(k);
+            sb.append("\":");
+            if (num.matcher(v).matches()) {
+                sb.append(v);
+            } else {
+                sb.append("\"");
+                sb.append(v);
+                sb.append("\"");
+            }
+            sb.append(",");
+        });
+        sb.setLength(sb.length() - 1);
+        sb.append("}");
+        return sb.toString();
+    }
+
+}

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildLogParserTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildLogParserTest.java
@@ -1,0 +1,110 @@
+package org.graalvm.tests.integration.utils;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+
+import static org.graalvm.tests.integration.utils.BuildLogParser.mapToJSON;
+import static org.graalvm.tests.integration.utils.BuildLogParser.parse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Tag("testing-testsuite")
+public class BuildLogParserTest {
+
+    @Test
+    public void parserTest() throws IOException {
+
+        final String log = ""
+                + "[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] Running Quarkus native-image plugin on native-image 22.1.0.0-Final Mandrel Distribution (Java Version 17.0.3+7)\n"
+                + "[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildRunner] /home/karm/workspaceRH/mandrel-release/CPU/mandrel-java17-22.1.0.0-Final/bin/native-image -J-DCoordinatorEnvironmentBean.transactionStatusManagerEnable=false -J-Dcom.sun.xml.bind.v2.bytecode.ClassTailor.noOptimize=true -J-Dsun.nio.ch.maxUpdateArraySize=100 -J-Djava.util.logging.manager=org.jboss.logmanager.LogManager -J-Dvertx.logger-delegate-factory-class-name=io.quarkus.vertx.core.runtime.VertxLogDelegateFactory -J-Dvertx.disableDnsResolver=true -J-Dio.netty.leakDetection.level=DISABLED -J-Dio.netty.allocator.maxOrder=3 -J-Duser.language=en -J-Duser.country=US -J-Dfile.encoding=UTF-8 -H:-ParseOnce -J--add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED -J--add-opens=java.base/java.text=ALL-UNNAMED -H:InitialCollectionPolicy=com.oracle.svm.core.genscavenge.CollectionPolicy\\$BySpaceAndTime -H:+JNI -H:+AllowFoldMethods -J-Djava.awt.headless=true -H:FallbackThreshold=0 --link-at-build-time -H:+ReportExceptionStackTraces -J-Xmx7g -H:-AddAllCharsets -H:EnableURLProtocols=http,https -H:NativeLinkerOption=-no-pie -H:-UseServiceLoaderFeature -H:+StackTrace qu-queue-service-1.0.0-SNAPSHOT-runner -jar qu-queue-service-1.0.0-SNAPSHOT-runner.jar\n"
+                + "========================================================================================================================\n"
+                + "GraalVM Native Image: Generating 'qu-queue-service-1.0.0-SNAPSHOT-runner' (executable)...\n"
+                + "========================================================================================================================\n"
+                + "[1/7] Initializing...                                                                                    (7.3s @ 0.23GB)\n"
+                + " Version info: 'GraalVM 22.1.0.0-Final Java 17 Mandrel Distribution'\n"
+                + " C compiler: gcc (redhat, x86_64, 8.5.0)\n"
+                + " Garbage collector: Serial GC\n"
+                + " 8 user-provided feature(s)\n"
+                + "  - io.quarkus.caffeine.runtime.graal.CacheConstructorsAutofeature\n"
+                + "  - io.quarkus.hibernate.orm.runtime.graal.DisableLoggingAutoFeature\n"
+                + "  - io.quarkus.jdbc.postgresql.runtime.graal.SQLXMLFeature\n"
+                + "  - io.quarkus.runner.AutoFeature\n"
+                + "  - io.quarkus.runtime.graal.DisableLoggingAutoFeature\n"
+                + "  - io.quarkus.runtime.graal.ResourcesFeature\n"
+                + "  - org.hibernate.graalvm.internal.GraalVMStaticAutofeature\n"
+                + "  - org.hibernate.graalvm.internal.QueryParsingSupport\n"
+                + "[2/7] Performing analysis...  [**********]                                                              (73.3s @ 3.12GB)\n"
+                + "  25,020 (92.12%) of 27,161 classes reachable\n"
+                + "  42,138 (64.32%) of 65,518 fields reachable\n"
+                + " 137,756 (60.29%) of 228,498 methods reachable\n"
+                + "   1,496 classes, 1,665 fields, and 11,499 methods registered for reflection\n"
+                + "      65 classes,    77 fields, and    55 methods registered for JNI access\n"
+                + "[3/7] Building universe...                                                                               (9.8s @ 2.53GB)\n"
+                + "[4/7] Parsing methods...      [****]                                                                    (14.8s @ 2.46GB)\n"
+                + "[5/7] Inlining methods...     [*****]                                                                   (16.1s @ 2.71GB)\n"
+                + "[6/7] Compiling methods...    [*******]                                                                 (54.7s @ 3.93GB)\n"
+                + "[7/7] Creating image...                                                                                 (11.3s @ 4.15GB)\n"
+                + "  54.88MB (42.32%) for code area:   92,869 compilation units\n"
+                + "  60.61MB (46.74%) for image heap:  17,698 classes and 641,980 objects\n"
+                + "  14.18MB (10.94%) for other data\n"
+                + " 129.68MB in total\n"
+                + "------------------------------------------------------------------------------------------------------------------------\n"
+                + "Top 10 packages in code area:                               Top 10 object types in image heap:\n"
+                + "   2.92MB jdk.proxy3                                          11.90MB byte[] for code metadata\n"
+                + "   2.59MB com.oracle.svm.core.reflect                         11.16MB byte[] for general heap data\n"
+                + "   2.04MB liquibase.pro.packaged                               6.27MB java.lang.Class\n"
+                + "   1.82MB sun.security.ssl                                     5.50MB byte[] for java.lang.String\n"
+                + "   1.17MB java.util                                            5.37MB java.lang.String\n"
+                + " 763.31KB com.sun.crypto.provider                              3.79MB java.lang.reflect.Method\n"
+                + " 746.55KB io.quarkus.runtime.generated                         2.10MB com.oracle.svm.core.hub.DynamicHubCompanion\n"
+                + " 622.12KB com.oracle.svm.core.code                             1.38MB byte[] for reflection metadata\n"
+                + " 614.87KB liquibase.command.core                               1.08MB java.lang.String[]\n"
+                + " 576.33KB org.hibernate.hql.internal.antlr                   851.44KB java.util.HashMap$Node\n"
+                + "      ... 1135 additional packages                                ... 5451 additional object types\n"
+                + "                                           (use GraalVM Dashboard to see all)\n"
+                + "------------------------------------------------------------------------------------------------------------------------\n"
+                + "                       24.7s (12.4% of total time) in 112 24.7s (12.4% of total time) in 112 GCs | Peak RSS: 6.44GB | CPU load: 6.61GCs | Peak RSS: 6.44GB | CPU load: 6.61\n"
+                + "------------------------------------------------------------------------------------------------------------------------\n"
+                + "Produced artifacts:\n"
+                + " /some/path/to/TEST-MARKER/qu-queue-service-1.0.0-SNAPSHOT-runner (executable)\n"
+                + " /some/path/to/somewhere/qu-queue-service-1.0.0-SNAPSHOT-runner.build_artifacts.txt\n"
+                + "========================================================================================================================\n"
+                + "Finished generating 'qu-queue-service-1.0.0-SNAPSHOT-runner' in 3m 17s.\n"
+                + "";
+        final File f = File.createTempFile("build-log-test", "txt");
+        Files.writeString(f.toPath(), log, StandardCharsets.UTF_8, StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING);
+
+        final String expected = ("{\n"
+                + "  \"buildTimeS\": 197,\n"
+                + "  \"classes\": 27161,\n"
+                + "  \"classesForJNIAccess\": 65,\n"
+                + "  \"classesForReflection\": 1496,\n"
+                + "  \"classesReachable\": 25020,\n"
+                + "  \"executablePath\": \"/some/path/to/somewhere/qu-queue-service-1.0.0-SNAPSHOT-runner\",\n"
+                + "  \"fields\": 65518,\n"
+                + "  \"fieldsForJNIAccess\": 77,\n"
+                + "  \"fieldsForReflection\": 1665,\n"
+                + "  \"fieldsReachable\": 42138,\n"
+                + "  \"jdkVersion\": \"17.0.3+7\",\n"
+                + "  \"mandrelVersion\": \"22.1.0.0-Final\",\n"
+                + "  \"methods\": 228498,\n"
+                + "  \"methodsForJNIAccess\": 55,\n"
+                + "  \"methodsForReflection\": 11499,\n"
+                + "  \"methodsReachable\": 137756,\n"
+                + "  \"numberOfGC\": 112,\n"
+                + "  \"peakRSSMB\": 6595,\n"
+                + "  \"timeInGCS\": 25\n"
+                + "}"
+        ).replaceAll("\\s*", "");
+        final String j = mapToJSON(parse(f.toPath()));
+        //System.out.println(j);
+        assertEquals(expected, j, "Parser is off.");
+    }
+
+}


### PR DESCRIPTION
It works, results already available at the stage collector:

```
$ curl -s -X GET -H "Accept: application/json" -H "token:${TR}" https://stage-collector.foci.life/api/report/time-and-size | jq
```

```json
[
  {
    "id": 2002,
    "arch": "amd64",
    "buildTimeS": 187,
    "classes": 26773,
    "classesForJNIAccess": 69,
    "classesForReflection": 1448,
    "classesReachable": 24598,
    "created": "2022-05-27T20:56:18.014",
    "executableSizeMB": 112,
    "fields": 63838,
    "fieldsForJNIAccess": 90,
    "fieldsForReflection": 1565,
    "fieldsReachable": 44762,
    "jdkVersion": "11.0.15+10",
    "mandrelVersion": "22.1.0.0-Final",
    "methods": 225077,
    "methodsForJNIAccess": 54,
    "methodsForReflection": 11226,
    "methodsReachable": 137824,
    "nativeImageXmXMB": 10240,
    "numberOfGC": 85,
    "os": "CentOS 8",
    "peakRSSMB": 7178,
    "quarkusVersion": "2.8.3.Final",
    "ramAvailableMB": 12478,
    "runnerDescription": "Local",
    "testApp": "https://github.com/Karm/dev-null/tree/issue-25672-1.0.0/issue-25672",
    "timeInGCS": 26
  },
  {
    "id": 2003,
    "arch": "amd64",
    "buildTimeS": 135,
    "classes": 27182,
    "classesForJNIAccess": 66,
    "classesForReflection": 1496,
    "classesReachable": 25017,
    "created": "2022-05-27T21:26:22.214",
    "executableSizeMB": 107,
    "fields": 65505,
    "fieldsForJNIAccess": 77,
    "fieldsForReflection": 1665,
    "fieldsReachable": 42156,
    "jdkVersion": "17.0.4-beta+2-202205122322",
    "mandrelVersion": "22.2.0-dev6fccf39aa33",
    "methods": 219309,
    "methodsForJNIAccess": 56,
    "methodsForReflection": 11473,
    "methodsReachable": 128247,
    "nativeImageXmXMB": 10240,
    "numberOfGC": 70,
    "os": "CentOS 8",
    "peakRSSMB": 6420,
    "quarkusVersion": "2.8.3.Final",
    "ramAvailableMB": 11940,
    "runnerDescription": "Local",
    "testApp": "https://github.com/Karm/dev-null/tree/issue-25672-1.0.0/issue-25672",
    "timeInGCS": 10
  }
]

```
TS started as:

```
$  mvn  clean verify \
-Ptestsuite \
-DexcludeTags=all \
-DincludeTags=perfcheck \
-Dperf.app.dir=/home/karm/workspaceRH/dev-null/issue-25672 \
-Dperf.app.arch=amd64 \
-Dperf.app.os="CentOS 8" \
-Dperf.app.xmxmb=10240 \
-Dperf.app.runner.description=Local \
-Dperf.app.url="https://github.com/Karm/dev-null/tree/issue-25672-1.0.0/issue-25672" \
-Dquarkus.version=2.8.3.Final \
-Dperf.app.secret.token=${TW} \
-Dperf.app.endpoint=https://stage-collector.foci.life/api/report/time-and-size
```



Additional polishing required, WIP....
