### PR TITLE
native-image executable file searched for static libs linked

### DIFF
--- a/.github/workflows/builder_image_tests.yml
+++ b/.github/workflows/builder_image_tests.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        quarkus-version: [ '1.11.7.Final', '2.5.4.Final', '2.7.5.Final' ]
+        quarkus-version: [ '1.11.7.Final', '2.5.4.Final', '2.7.6.Final' ]
         mandrel-builder-image: [
             '20.3-java11',
             '21.2-java11',
@@ -54,9 +54,9 @@ jobs:
             mandrel-builder-image: '22.0-java11'
           - quarkus-version: '2.5.4.Final'
             mandrel-builder-image: '22.0-java17'
-          - quarkus-version: '2.7.5.Final'
+          - quarkus-version: '2.7.6.Final'
             mandrel-builder-image: '20.3-java11'
-          - quarkus-version: '2.7.5.Final'
+          - quarkus-version: '2.7.6.Final'
             mandrel-builder-image: '21.2-java11'
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/local_tests.yml
+++ b/.github/workflows/local_tests.yml
@@ -23,8 +23,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        quarkus-version: [ '1.11.7.Final', '2.5.4.Final', '2.7.5.Final' ]
-        mandrel-version: [ '20.3.3.0-Final', '21.2.0.2-Final', '21.3.1.1-Final', '22.0.0.2-Final' ]
+        quarkus-version: [ '1.11.7.Final', '2.5.4.Final', '2.7.6.Final' ]
+        mandrel-version: [ '20.3.3.0-Final', '21.2.0.2-Final', '21.3.2.0-Final', '22.1.0.0-Final' ]
         java-version: [ '11', '17' ]
         os: [ ubuntu-20.04, windows-2019 ]
         exclude:
@@ -38,16 +38,16 @@ jobs:
             mandrel-version: '21.2.0.2-Final'
             java-version: '17'
           - quarkus-version: '1.11.7.Final'
-            mandrel-version: '21.3.1.1-Final'
+            mandrel-version: '21.3.2.0-Final'
             java-version: '11'
           - quarkus-version: '1.11.7.Final'
-            mandrel-version: '21.3.1.1-Final'
+            mandrel-version: '21.3.2.0-Final'
             java-version: '17'
           - quarkus-version: '1.11.7.Final'
-            mandrel-version: '22.0.0.2-Final'
+            mandrel-version: '22.1.0.0-Final'
             java-version: '11'
           - quarkus-version: '1.11.7.Final'
-            mandrel-version: '22.0.0.2-Final'
+            mandrel-version: '22.1.0.0-Final'
             java-version: '17'
           - quarkus-version: '2.5.4.Final'
             mandrel-version: '20.3.3.0-Final'
@@ -56,27 +56,27 @@ jobs:
             mandrel-version: '20.3.3.0-Final'
             java-version: '17'
           - quarkus-version: '2.5.4.Final'
-            mandrel-version: '22.0.0.2-Final'
+            mandrel-version: '22.1.0.0-Final'
             java-version: '11'
           - quarkus-version: '2.5.4.Final'
-            mandrel-version: '22.0.0.2-Final'
+            mandrel-version: '22.1.0.0-Final'
             java-version: '17'
           - quarkus-version: '2.5.4.Final'
             mandrel-version: '21.2.0.2-Final'
             java-version: '17'
           - quarkus-version: '2.5.4.Final'
-            mandrel-version: '21.3.1.1-Final'
+            mandrel-version: '21.3.2.0-Final'
             java-version: '17'
-          - quarkus-version: '2.7.5.Final'
+          - quarkus-version: '2.7.6.Final'
             mandrel-version: '20.3.3.0-Final'
             java-version: '11'
-          - quarkus-version: '2.7.5.Final'
+          - quarkus-version: '2.7.6.Final'
             mandrel-version: '20.3.3.0-Final'
             java-version: '17'
-          - quarkus-version: '2.7.5.Final'
+          - quarkus-version: '2.7.6.Final'
             mandrel-version: '21.2.0.2-Final'
             java-version: '11'
-          - quarkus-version: '2.7.5.Final'
+          - quarkus-version: '2.7.6.Final'
             mandrel-version: '21.2.0.2-Final'
             java-version: '17'
     steps:

--- a/.github/workflows/testing_testsuite.yml
+++ b/.github/workflows/testing_testsuite.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mandrel-version: [ '21.3.1.1-Final', '22.0.0.2-Final' ]
+        mandrel-version: [ '21.3.2.0-Final', '22.1.0.0-Final' ]
         java-version: [ '11', '17' ]
         os: [ ubuntu-20.04, windows-2019 ]
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <!-- Quarkus apps -->
         <!-- Note that the TS switches Quarkus version at test run,
              see Commands.java, QUARKUS_VERSION -->
-        <global.quarkus.version>2.2.3.Final</global.quarkus.version>
+        <global.quarkus.version>2.7.6.Final</global.quarkus.version>
 
         <!-- Micronaut minimal app -->
         <micronaut.version>2.3.0</micronaut.version>

--- a/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
@@ -463,20 +463,18 @@ public class AppReproducersTest {
 
             // Test static libs in the executable
             final File executable = new File(appDir.getAbsolutePath() + File.separator + "target", "imageio");
-            final Set<String> expected;
-            //@formatter:off
+            final Set<String> expected = Set.of("libawt.a", "libawt_headless.a", "libfdlibm.a", "libfontmanager.a", "libjava.a", "libjavajpeg.a", "libjvm.a", "liblcms.a", "liblibchelper.a", "libnet.a", "libnio.a", "libzip.a");
             if (UsedVersion.getVersion(inContainer).compareTo(Version.create(22, 2, 0)) >= 0) {
-             // libmanagement_ext.a added in 22.2 with https://github.com/oracle/graal/commit/a0e6a3aeb8b63f6c06dc3554c342075534d90796
-             // expected = Set.of("libawt.a", "libawt_headless.a", "libfdlibm.a", "libfontmanager.a",                  "libjava.a", "libjavajpeg.a", "libjvm.a", "liblcms.a", "liblibchelper.a", "libmanagement_ext.a", "libnet.a", "libnio.a", "libzip.a");
-             // libmanagement_ext.a removed again: https://github.com/oracle/graal/pull/4383
-                expected = Set.of("libawt.a", "libawt_headless.a", "libfdlibm.a", "libfontmanager.a",                  "libjava.a", "libjavajpeg.a", "libjvm.a", "liblcms.a", "liblibchelper.a",                         "libnet.a", "libnio.a", "libzip.a");
+                // libmanagement_ext.a added in 22.2 with https://github.com/oracle/graal/commit/a0e6a3aeb8b63f6c06dc3554c342075534d90796
+                // expected.add("libmanagement_ext.a");
+                // libmanagement_ext.a removed again: https://github.com/oracle/graal/pull/4383
+                // NO-OP
             } else if (UsedVersion.jdkFeature(inContainer) > 11 || (UsedVersion.jdkFeature(inContainer) == 11 && UsedVersion.jdkUpdate(inContainer) > 12)) {
                 // Harfbuzz removed: https://github.com/graalvm/mandrel/issues/286
-                expected = Set.of("libawt.a", "libawt_headless.a", "libfdlibm.a", "libfontmanager.a",                  "libjava.a", "libjavajpeg.a", "libjvm.a", "liblcms.a", "liblibchelper.a",                         "libnet.a", "libnio.a", "libzip.a");
+                // NO-OP
             } else {
-                expected = Set.of("libawt.a", "libawt_headless.a", "libfdlibm.a", "libfontmanager.a", "libharfbuzz.a", "libjava.a", "libjavajpeg.a", "libjvm.a", "liblcms.a", "liblibchelper.a",                         "libnet.a", "libnio.a", "libzip.a");
+                expected.add("libharfbuzz.a");
             }
-            //@formatter:on
 
             final Set<String> actual = listStaticLibs(executable);
 


### PR DESCRIPTION
The report makes much more sense now:

```
[ERROR] imageioAWTTest{TestInfo}  Time elapsed: 0.121 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: 
A different set of static libraries was expected. 
Expected: [libawt.a, libawt_headless.a, libfdlibm.a, libfontmanager.a, libjava.a, libjavajpeg.a, libjvm.a, liblcms.a, liblibchelper.a, libmanagement_ext.a, libnet.a, libnio.a, libzip.a]
Actual:   [libawt.a, libawt_headless.a, libfdlibm.a, libfontmanager.a, libjava.a, libjavajpeg.a, libjvm.a, liblcms.a, liblibchelper.a, libnet.a, libnio.a, libzip.a] ==> expected: <true> but was: <false>
        at org.graalvm.tests.integration.AppReproducersTest.imageioAWT(AppReproducersTest.java:485)
        at org.graalvm.tests.integration.AppReproducersTest.imageioAWTTest(AppReproducersTest.java:359)

```

Let's see if the conditions hold across various Mandrel versions.

Tested locally with:
 * native-image 22.2.0-deve328151c532 Mandrel Distribution (Java Version 17.0.2-internal+0-adhoc.tester.jdk17) :heavy_check_mark: 
 * native-image 22.2.0-deve328151c532 Mandrel Distribution (Java Version 11.0.17-internal+0-adhoc.tester.jdk11) :heavy_check_mark: 


