### PR TITLE
Whitelist warning for illegal reflective access

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
@@ -40,7 +40,8 @@ public enum WhitelistLogLines {
             // JDK:
             Pattern.compile("WARNING.* reflective access.*"),
             Pattern.compile("WARNING: All illegal access operations.*"),
-            Pattern.compile("WARNING: Please consider reporting this to the maintainers of com.google.inject.internal.cglib.*")
+            Pattern.compile("WARNING: Please consider reporting this to the maintainers of com.google.inject.internal.cglib.*"),
+            Pattern.compile("WARNING: Please consider reporting this to the maintainers of com.fasterxml.jackson.databind.util.*")
     }),
 
     NONE(new Pattern[]{}),


### PR DESCRIPTION
Avoids:

```
Error:  Failures: 
Error:    DebugSymbolsTest.debugSymbolsQuarkus:224 build-and-run.log log should not contain error or warning lines that are not whitelisted. See /home/runner/work/mandrel/mandrel/mandrel-integration-tests/testsuite/target/archived-logs/org.graalvm.tests.integration.DebugSymbolsTest/debugSymbolsQuarkus/build-and-run.log and check these offending lines: 
WARNING: Please consider reporting this to the maintainers of com.fasterxml.jackson.databind.util.ClassUtil$EnumTypeLocator ==> expected: <true> but was: <false>
Error:    RuntimesSmokeTest.quarkusFullMicroProfile:201->testRuntime:167 build-and-run.log log should not contain error or warning lines that are not whitelisted. See /home/runner/work/mandrel/mandrel/mandrel-integration-tests/testsuite/target/archived-logs/org.graalvm.tests.integration.RuntimesSmokeTest/quarkusFullMicroProfile/build-and-run.log and check these offending lines: 
WARNING: Please consider reporting this to the maintainers of com.fasterxml.jackson.databind.util.ClassUtil$EnumTypeLocator ==> expected: <true> but was: <false>
```

See https://github.com/graalvm/mandrel/runs/7189889547?check_suite_focus=true#step:10:18575