### PR TITLE
Whitelist warning for missing com.orsoncharts.Chart3DHints

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/Apps.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/Apps.java
@@ -91,7 +91,7 @@ public enum Apps {
             ContainerNames.NONE),
     IMAGEIO("apps" + File.separator + "imageio",
             URLContent.NONE,
-            WhitelistLogLines.NONE,
+            WhitelistLogLines.IMAGEIO,
             BuildAndRunCmds.IMAGEIO,
             ContainerNames.NONE),
     IMAGEIO_BUILDER_IMAGE("apps" + File.separator + "imageio",

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
@@ -55,11 +55,18 @@ public enum WhitelistLogLines {
             Pattern.compile(".*Failed to create WindowsAnsiOutputStream.*")
     }),
 
+    IMAGEIO(new Pattern[]{
+            // org.jfree.jfreesvg reflectively accesses com.orsoncharts.Chart3DHints which is not on the classpath
+            Pattern.compile("Warning: Could not resolve com.orsoncharts.Chart3DHints for reflection configuration. Reason: java.lang.ClassNotFoundException: com.orsoncharts.Chart3DHints.")
+    }),
+
     IMAGEIO_BUILDER_IMAGE(new Pattern[]{
             // Dnf warnings...
             Pattern.compile(".*librhsm-WARNING.*"),
             // Podman with cgroupv2 on RHEL 9 intermittently spits out this message to no apparent effect on our tests
-            Pattern.compile(".*time=.*level=warning.*msg=.*S.gpg-agent.*since it is a socket.*")
+            Pattern.compile(".*time=.*level=warning.*msg=.*S.gpg-agent.*since it is a socket.*"),
+            // org.jfree.jfreesvg reflectively accesses com.orsoncharts.Chart3DHints which is not on the classpath
+            Pattern.compile("Warning: Could not resolve com.orsoncharts.Chart3DHints for reflection configuration. Reason: java.lang.ClassNotFoundException: com.orsoncharts.Chart3DHints.")
     }),
 
     QUARKUS_FULL_MICROPROFILE(new Pattern[]{


### PR DESCRIPTION
org.jfree.jfreesvg reflectively accesses com.orsoncharts.Chart3DHints
[1] which is not on the classpath

[1] https://github.com/jfree/jfreesvg/blob/1d8cfa22a8001178102871c54d2de65f8f2aca26/src/main/java/org/jfree/svg/SVGHints.java#L508-L518