### PR TITLE
Add libmanagement_ext.a as an expected static lib.

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
@@ -464,11 +464,11 @@ public class AppReproducersTest {
             // Test static libs in the executable
             final File executable = new File(appDir.getAbsolutePath() + File.separator + "target", "imageio");
             final Set<String> expected = Set.of("libawt.a", "libawt_headless.a", "libfdlibm.a", "libfontmanager.a", "libjava.a", "libjavajpeg.a", "libjvm.a", "liblcms.a", "liblibchelper.a", "libnet.a", "libnio.a", "libzip.a");
-            if (UsedVersion.getVersion(inContainer).compareTo(Version.create(22, 2, 0)) >= 0) {
-                // libmanagement_ext.a added in 22.2 with https://github.com/oracle/graal/commit/a0e6a3aeb8b63f6c06dc3554c342075534d90796
-                // expected.add("libmanagement_ext.a");
-                // libmanagement_ext.a removed again: https://github.com/oracle/graal/pull/4383
-                // NO-OP
+            if (UsedVersion.getVersion(inContainer).compareTo(Version.create(22, 3, 0)) >= 0) {
+                // libmanagement_ext.a added in 22.2+ with https://github.com/oracle/graal/commit/a0e6a3aeb8b63f6c06dc3554c342075534d90796
+                // but it wasn't deemed reachable until by the later commit https://github.com/oracle/graal/commit/2e3a0ae220f202be8f92f8738b9ba3aea57aea7d
+                // Therefore we expect it only for 22.3+
+                expected.add("libmanagement_ext.a");
             } else if (UsedVersion.jdkFeature(inContainer) > 11 || (UsedVersion.jdkFeature(inContainer) == 11 && UsedVersion.jdkUpdate(inContainer) > 12)) {
                 // Harfbuzz removed: https://github.com/graalvm/mandrel/issues/286
                 // NO-OP


### PR DESCRIPTION
The comments in the code suggest that some code in graal master got added and removed again, but https://github.com/oracle/graal/commit/a0e6a3aeb8b63f6c06dc3554c342075534d90796 was actually added with PR https://github.com/oracle/graal/pull/4383. The JDK static lib is being used as the relevant class is reachable for that application.

Closes: #109