### PR TITLE
Attempt test fix for resource locations

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
@@ -303,6 +303,15 @@ public class AppReproducersTest {
         resLocations(testInfo, Apps.RESLOCATIONS, expectedOutput);
     }
 
+    /**
+     * Resources handling changed:
+     *     3: N/A -> JDK
+     *    14: N/A -> JDK
+     * In https://github.com/oracle/graal/commit/8faf577
+     * @param testInfo
+     * @throws IOException
+     * @throws InterruptedException
+     */
     @Test
     @Tag("resources")
     @IfMandrelVersion(min = "22.3")

--- a/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
@@ -250,7 +250,7 @@ public class AppReproducersTest {
 
     @Test
     @Tag("resources")
-    @IfMandrelVersion(min = "22.1")
+    @IfMandrelVersion(min = "22.1", max = "22.2")
     public void resLocationsC(TestInfo testInfo) throws IOException, InterruptedException {
         final String expectedOutput = "" +
                 "Resources folders:\n" +
@@ -283,6 +283,61 @@ public class AppReproducersTest {
                 "12: APP\n" +
                 "13: N/A\n" +
                 "14: N/A\n" +
+                "15: N/A\n" +
+                "16: JDK\n" +
+                "17: N/A\n" +
+                "18: N/A\n" +
+                "19: JDK\n" +
+                "20: JDK\n" +
+                "21: N/A\n" +
+                "22: N/A\n" +
+                "23: JDK\n" +
+                "24: JDK\n" +
+                "25: N/A\n" +
+                "26: N/A\n" +
+                "27: JDK\n" +
+                "28: N/A\n" +
+                "29: N/A\n" +
+                "30: JDK\n" +
+                "31: N/A\n";
+        resLocations(testInfo, Apps.RESLOCATIONS, expectedOutput);
+    }
+
+    @Test
+    @Tag("resources")
+    @IfMandrelVersion(min = "22.3")
+    public void resLocationsD(TestInfo testInfo) throws IOException, InterruptedException {
+        final String expectedOutput = "" +
+                "Resources folders:\n" +
+                "0:  N/A\n" +
+                "1:  N/A\n" +
+                "2:  N/A\n" +
+                "3:  N/A\n" +
+                "4:  NO_SLASH FOLDER\n" +
+                "5:  SLASH FOLDER\n" +
+                "6:  N/A\n" +
+                "7:  N/A\n" +
+                "8:  N/A\n" +
+                "9:  N/A\n" +
+                "10: N/A\n" +
+                "11: N/A\n" +
+                "\n" +
+                "iio-plugin.properties:\n" +
+                "0:  N/A\n" +
+                "1:  APP\n" +
+                "2:  N/A\n" +
+                "3:  JDK\n" +
+                "4:  JDK\n" +
+                "5:  N/A\n" +
+                "6:  N/A\n" +
+                "7:  JDK\n" +
+                "8:  JDK\n" +
+                "9:  N/A\n" +
+                "10: N/A\n" +
+                "11: JDK\n" +
+                "12: APP\n" +
+                "13: N/A\n" +
+                "14: JDK\n" +
                 "15: N/A\n" +
                 "16: JDK\n" +
                 "17: N/A\n" +


### PR DESCRIPTION
As discussed in #108. 

```
MethodHandles.lookup().lookupClass().getResourceAsStream("/com/sun/imageio/plugins/common/iio-plugin.properties")
```
and

```
Thread.currentThread().getContextClassLoader().getResourceAsStream("com/sun/imageio/plugins/common/iio-plugin.properties")
```

Changed from `N/A` to `JDK`. It doesn't seem to affect quarkus integration tests (`awt`).

Closes: #108