### PR TITLE
Don't expect management_ext.a for imageio test

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
@@ -529,14 +529,7 @@ public class AppReproducersTest {
             // Test static libs in the executable
             final File executable = new File(appDir.getAbsolutePath() + File.separator + "target", "imageio");
             Set<String> expected = Set.of("libawt.a", "libawt_headless.a", "libfdlibm.a", "libfontmanager.a", "libjava.a", "libjavajpeg.a", "libjvm.a", "liblcms.a", "liblibchelper.a", "libnet.a", "libnio.a", "libzip.a");
-            if (UsedVersion.getVersion(inContainer).compareTo(Version.create(22, 3, 0)) >= 0) {
-                // libmanagement_ext.a added in 22.2+ with https://github.com/oracle/graal/commit/a0e6a3aeb8b63f6c06dc3554c342075534d90796
-                // but it wasn't deemed reachable until by the later commit https://github.com/oracle/graal/commit/2e3a0ae220f202be8f92f8738b9ba3aea57aea7d
-                // Therefore we expect it only for 22.3+
-                Set<String> modifiable = new HashSet<>(expected);
-                modifiable.add("libmanagement_ext.a");
-                expected = Collections.unmodifiableSet(modifiable);
-            } else if (UsedVersion.jdkFeature(inContainer) > 11 || (UsedVersion.jdkFeature(inContainer) == 11 && UsedVersion.jdkUpdate(inContainer) > 12)) {
+            if (UsedVersion.jdkFeature(inContainer) > 11 || (UsedVersion.jdkFeature(inContainer) == 11 && UsedVersion.jdkUpdate(inContainer) > 12)) {
                 // Harfbuzz removed: https://github.com/graalvm/mandrel/issues/286
                 // NO-OP
             } else {

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildAndRunCmds.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildAndRunCmds.java
@@ -101,9 +101,9 @@ public enum BuildAndRunCmds {
     }),
     IMAGEIO(new String[][]{
             new String[]{"mvn", "clean", "package"},
-            new String[]{"java", "-agentlib:native-image-agent=config-output-dir=src/main/resources/META-INF/native-image", "-jar", "target/imageio.jar"},
+            new String[]{"java", "-Djava.awt.headless=true", "-agentlib:native-image-agent=config-output-dir=src/main/resources/META-INF/native-image", "-jar", "target/imageio.jar"},
             new String[]{"jar", "uf", "target/imageio.jar", "-C", "src/main/resources/", "META-INF"},
-            new String[]{"native-image", "-H:IncludeResources=Grace_M._Hopper.jp2,MyFreeMono.ttf,MyFreeSerif.ttf", "--no-fallback", "-jar", "target/imageio.jar", "target/imageio"},
+            new String[]{"native-image", "-J-Djava.awt.headless=true", "-H:IncludeResources=Grace_M._Hopper.jp2,MyFreeMono.ttf,MyFreeSerif.ttf", "--no-fallback", "-jar", "target/imageio.jar", "target/imageio"},
             new String[]{IS_THIS_WINDOWS ? "target\\imageio.exe" : "./target/imageio"}
     }),
     IMAGEIO_BUILDER_IMAGE(new String[][]{
@@ -112,7 +112,7 @@ public enum BuildAndRunCmds {
             // TODO: Ad -u: Test access rights with -u on Windows, Docker Desktop Hyper-V backend vs. WSL2 backend.
             // Java from Builder image container is used for the sake of consistence.
             new String[]{CONTAINER_RUNTIME, "run", IS_THIS_WINDOWS ? "" : "-u", IS_THIS_WINDOWS ? "" : getUnixUIDGID(),
-                    "-t", "--entrypoint", "java", "-v", BASE_DIR + File.separator + "apps" + File.separator + "imageio:/project:z",
+                    "-t", "--entrypoint", "java", "-Djava.awt.headless=true", "-v", BASE_DIR + File.separator + "apps" + File.separator + "imageio:/project:z",
                     BUILDER_IMAGE,
                     "-agentlib:native-image-agent=config-output-dir=src/main/resources/META-INF/native-image", "-jar", "target/imageio.jar"},
             // Jar could be used locally, but we use the one from container too.
@@ -124,7 +124,7 @@ public enum BuildAndRunCmds {
             new String[]{CONTAINER_RUNTIME, "run", IS_THIS_WINDOWS ? "" : "-u", IS_THIS_WINDOWS ? "" : getUnixUIDGID(),
                     "-t", "-v", BASE_DIR + File.separator + "apps" + File.separator + "imageio:/project:z",
                     BUILDER_IMAGE,
-                    "-H:IncludeResources=Grace_M._Hopper.jp2,MyFreeMono.ttf,MyFreeSerif.ttf", "--no-fallback", "-jar", "target/imageio.jar", "target/imageio"},
+                    "-J-Djava.awt.headless=true", "-H:IncludeResources=Grace_M._Hopper.jp2,MyFreeMono.ttf,MyFreeSerif.ttf", "--no-fallback", "-jar", "target/imageio.jar", "target/imageio"},
             // We build a runtime image, ubi 8 minimal based, runtime dependencies installed
             new String[]{CONTAINER_RUNTIME, "build", "--network=host", "-t", ContainerNames.IMAGEIO_BUILDER_IMAGE.name, "."},
             // We have to run int he same env as we run the java part above, i.e. in the same container base.

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildAndRunCmds.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildAndRunCmds.java
@@ -112,8 +112,8 @@ public enum BuildAndRunCmds {
             // TODO: Ad -u: Test access rights with -u on Windows, Docker Desktop Hyper-V backend vs. WSL2 backend.
             // Java from Builder image container is used for the sake of consistence.
             new String[]{CONTAINER_RUNTIME, "run", IS_THIS_WINDOWS ? "" : "-u", IS_THIS_WINDOWS ? "" : getUnixUIDGID(),
-                    "-t", "--entrypoint", "java", "-Djava.awt.headless=true", "-v", BASE_DIR + File.separator + "apps" + File.separator + "imageio:/project:z",
-                    BUILDER_IMAGE,
+                    "-t", "--entrypoint", "java", "-v", BASE_DIR + File.separator + "apps" + File.separator + "imageio:/project:z",
+                    BUILDER_IMAGE, "-Djava.awt.headless=true",
                     "-agentlib:native-image-agent=config-output-dir=src/main/resources/META-INF/native-image", "-jar", "target/imageio.jar"},
             // Jar could be used locally, but we use the one from container too.
             new String[]{CONTAINER_RUNTIME, "run", IS_THIS_WINDOWS ? "" : "-u", IS_THIS_WINDOWS ? "" : getUnixUIDGID(),


### PR DESCRIPTION
This patch explicitly sets `-Djava.awt.headless=true` everywhere so that we aren't at the whim of whatever `GraphicsEnvironment.isHeadless()` deems the currently running system is in terms of headful or headless. Apparently CI systems are different. This rules out a headful build.

After https://github.com/oracle/graal/pull/5122 is merged, we should have that test passing everywhere (including 23.0.0-dev and 22.3.0-dev - once we backport there).

First part to close #117.