### PR TITLE
Locales/encoding related build gets bigger on RHEL9

### DIFF
--- a/builder-image-apps/quarkus-spöklik-encoding/threshold.properties
+++ b/builder-image-apps/quarkus-spöklik-encoding/threshold.properties
@@ -3,7 +3,9 @@ linux.RSS.threshold.kB=55000
 #Mandrel 20.3
 #linux.executable.size.threshold.kB=30478
 #Mandrel 21.1
-linux.executable.size.threshold.kB=41700
+#linux.executable.size.threshold.kB=41700
+# Mandrel 21x on RHEL 9; RHEL 8 based build is somewhat smaller.
+linux.executable.size.threshold.kB=44800
 windows.time.to.first.ok.request.threshold.ms=1100
 windows.RSS.threshold.kB=55000
 windows.executable.size.threshold.kB=30478


### PR DESCRIPTION
This has been around f a long time, nagging in reports. Anything that includes localization on RHEL 9 gets bigger than on RHEL 8. I am lifting the threshold.