### PR TITLE
Fail instead of throwing NPE when Process is null

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
@@ -104,6 +104,7 @@ public class AppReproducersTest {
             LOGGER.info("Running...#1");
             List<String> cmd = getRunCommand(app.buildAndRunCmds.cmds[app.buildAndRunCmds.cmds.length - 1]);
             process = runCommand(cmd, appDir, processLog, app);
+            assertNotNull(process, "The test application failed to run. Check " + getLogsDir(cn, mn) + File.separator + processLog.getName());
             process.waitFor(5, TimeUnit.SECONDS);
             Logs.appendln(report, appDir.getAbsolutePath());
             Logs.appendlnSection(report, String.join(" ", cmd));
@@ -111,6 +112,7 @@ public class AppReproducersTest {
             LOGGER.info("Running...#2");
             cmd = getRunCommand(app.buildAndRunCmds.cmds[app.buildAndRunCmds.cmds.length - 1]);
             process = runCommand(cmd, appDir, processLog, app);
+            assertNotNull(process, "The test application failed to run. Check " + getLogsDir(cn, mn) + File.separator + processLog.getName());
             process.waitFor(5, TimeUnit.SECONDS);
             Logs.appendln(report, appDir.getAbsolutePath());
             Logs.appendlnSection(report, String.join(" ", cmd));
@@ -486,6 +488,7 @@ public class AppReproducersTest {
             LOGGER.info("Running...");
             final List<String> cmd = getRunCommand(app.buildAndRunCmds.cmds[app.buildAndRunCmds.cmds.length - 1]);
             process = runCommand(cmd, appDir, processLog, app);
+            assertNotNull(process, "The test application failed to run. Check " + getLogsDir(cn, mn) + File.separator + processLog.getName());
             process.waitFor(15, TimeUnit.SECONDS);
             Logs.appendln(report, appDir.getAbsolutePath());
             Logs.appendlnSection(report, String.join(" ", cmd));
@@ -591,6 +594,7 @@ public class AppReproducersTest {
             LOGGER.info("Running...");
             List<String> cmd = getRunCommand(app.buildAndRunCmds.cmds[app.buildAndRunCmds.cmds.length - 1]);
             process = runCommand(cmd, appDir, processLog, app);
+            assertNotNull(process, "The test application failed to run. Check " + getLogsDir(cn, mn) + File.separator + processLog.getName());
             process.waitFor(5, TimeUnit.SECONDS);
             Logs.appendln(report, appDir.getAbsolutePath());
             Logs.appendlnSection(report, String.join(" ", cmd));
@@ -771,6 +775,7 @@ public class AppReproducersTest {
             long start = System.currentTimeMillis();
             List<String> cmd = getRunCommand(app.buildAndRunCmds.cmds[app.buildAndRunCmds.cmds.length - 2]);
             process = runCommand(cmd, appDir, processLog, app, inputData);
+            assertNotNull(process, "The test application failed to run. Check " + getLogsDir(cn, mn) + File.separator + processLog.getName());
             process.waitFor(30, TimeUnit.SECONDS);
             long jvmRunTookMs = System.currentTimeMillis() - start;
             Logs.appendln(report, appDir.getAbsolutePath());
@@ -780,6 +785,7 @@ public class AppReproducersTest {
             start = System.currentTimeMillis();
             cmd = getRunCommand(app.buildAndRunCmds.cmds[app.buildAndRunCmds.cmds.length - 1]);
             process = runCommand(cmd, appDir, processLog, app, inputData);
+            assertNotNull(process, "The test application failed to run. Check " + getLogsDir(cn, mn) + File.separator + processLog.getName());
             process.waitFor(30, TimeUnit.SECONDS);
             long nativeRunTookMs = System.currentTimeMillis() - start;
             Logs.appendln(report, appDir.getAbsolutePath());

--- a/testsuite/src/it/java/org/graalvm/tests/integration/DebugSymbolsTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/DebugSymbolsTest.java
@@ -25,7 +25,6 @@ import org.graalvm.tests.integration.utils.GDBSession;
 import org.graalvm.tests.integration.utils.Logs;
 import org.graalvm.tests.integration.utils.WebpageTester;
 import org.graalvm.tests.integration.utils.versions.QuarkusVersion;
-import org.graalvm.tests.integration.utils.versions.UsedVersion;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -64,6 +63,7 @@ import static org.graalvm.tests.integration.utils.Commands.stopAllRunningContain
 import static org.graalvm.tests.integration.utils.Commands.stopRunningContainers;
 import static org.graalvm.tests.integration.utils.Commands.waitForBufferToMatch;
 import static org.graalvm.tests.integration.utils.Commands.waitForContainerLogToMatch;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -109,6 +109,7 @@ public class DebugSymbolsTest {
             processBuilder.directory(appDir)
                     .redirectErrorStream(true);
             final Process process = processBuilder.start();
+            assertNotNull(process, "GDB process failed to start.");
             final ExecutorService esvc = Executors.newCachedThreadPool();
             final StringBuffer stringBuffer = new StringBuffer();
             final Runnable reader = () -> {
@@ -179,6 +180,7 @@ public class DebugSymbolsTest {
             processBuilder.directory(appDir)
                     .redirectErrorStream(true);
             final Process process = processBuilder.start();
+            assertNotNull(process, "GDB process failed to start.");
             final ExecutorService esvc = Executors.newCachedThreadPool();
             final StringBuffer stringBuffer = new StringBuffer();
             final Runnable reader = () -> {
@@ -289,6 +291,7 @@ public class DebugSymbolsTest {
             final Map<String, String> envA = processBuilder.environment();
             envA.put("PATH", System.getenv("PATH"));
             final Process gdbProcess = processBuilder.start();
+            assertNotNull(gdbProcess, "GDB process in container failed to start.");
             final ExecutorService esvc = Executors.newCachedThreadPool();
             final StringBuffer stringBuffer = new StringBuffer();
             final Runnable reader = () -> {

--- a/testsuite/src/it/java/org/graalvm/tests/integration/JFRTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/JFRTest.java
@@ -56,6 +56,8 @@ import static org.graalvm.tests.integration.utils.Commands.removeContainers;
 import static org.graalvm.tests.integration.utils.Commands.replaceSwitchesInCmd;
 import static org.graalvm.tests.integration.utils.Commands.runCommand;
 import static org.graalvm.tests.integration.utils.Commands.stopAllRunningContainers;
+import static org.graalvm.tests.integration.utils.Logs.getLogsDir;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -141,6 +143,7 @@ public class JFRTest {
                 cmd = replaceSwitchesInCmd(cmd, Map.of(JFR_FLIGHT_RECORDER_HOTSPOT_TOKEN, JFROption.HOTSPOT_11_FLIGHT_RECORDER.replacement));
             }
             process = runCommand(cmd, appDir, processLog, app, inputData);
+            assertNotNull(process, "The test application failed to run. Check " + getLogsDir(cn, mn) + File.separator + processLog.getName());
             process.waitFor(30, TimeUnit.SECONDS);
             long jvmRunTookMs = System.currentTimeMillis() - start;
             Logs.appendln(report, appDir.getAbsolutePath());
@@ -150,6 +153,7 @@ public class JFRTest {
             start = System.currentTimeMillis();
             cmd = getRunCommand(app.buildAndRunCmds.cmds[app.buildAndRunCmds.cmds.length - 1]);
             process = runCommand(cmd, appDir, processLog, app, inputData);
+            assertNotNull(process, "The test application failed to run. Check " + getLogsDir(cn, mn) + File.separator + processLog.getName());
             process.waitFor(30, TimeUnit.SECONDS);
             long nativeRunTookMs = System.currentTimeMillis() - start;
             Logs.appendln(report, appDir.getAbsolutePath());
@@ -308,6 +312,7 @@ public class JFRTest {
                     final List<String> cmd = getRunCommand(co.getKey());
                     Files.writeString(interimLog, String.join(" ", cmd) + "\n", StandardOpenOption.CREATE_NEW);
                     final Process p = runCommand(cmd, appDir, interimLog.toFile(), app);
+                    assertNotNull(p, "Process failed to run.");
                     p.waitFor(3, TimeUnit.SECONDS);
                     Logs.appendln(report, appDir.getAbsolutePath());
                     Logs.appendlnSection(report, String.join(" ", cmd));

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/Commands.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/Commands.java
@@ -176,7 +176,7 @@ public class Commands {
         final InetSocketAddress socketAddr = new InetSocketAddress(address, port);
         while (now - startTime < 1000 * loopTimeoutS) {
             try (Socket socket = new Socket()) {
-                // If it let's you write something there, it is still ready.
+                // If it lets you write something there, it is still ready.
                 socket.connect(socketAddr, 1000);
                 socket.setSendBufferSize(1);
                 socket.getOutputStream().write(1);
@@ -200,7 +200,7 @@ public class Commands {
     /**
      * There might be this weird glitch where native-image command completes
      * but the FS does not appear to have the resulting binary ready and executable for the
-     * next process *immediately*. Hence this small wait that mitigates this glitch.
+     * next process *immediately*. Hence, this small wait that mitigates this glitch.
      *
      * Note that nothing happens at the end of the timeout and the TS hopes for the best.
      *


### PR DESCRIPTION
Small UX improvement: If the executable fails to start, e.g. native image not built, it throws an NPE. JUnit failure is better in that case to understand for an uninitiated reader.