### PR TITLE
Fix orsoncharts allowlist

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
@@ -57,7 +57,7 @@ public enum WhitelistLogLines {
 
     IMAGEIO(new Pattern[]{
             // org.jfree.jfreesvg reflectively accesses com.orsoncharts.Chart3DHints which is not on the classpath
-            Pattern.compile("Warning: Could not resolve com.orsoncharts.Chart3DHints for reflection configuration. Reason: java.lang.ClassNotFoundException: com.orsoncharts.Chart3DHints.")
+            Pattern.compile("Warning: Could not resolve .*com.orsoncharts.Chart3DHints for reflection configuration. Reason: java.lang.ClassNotFoundException: com.orsoncharts.Chart3DHints.")
     }),
 
     IMAGEIO_BUILDER_IMAGE(new Pattern[]{
@@ -66,7 +66,7 @@ public enum WhitelistLogLines {
             // Podman with cgroupv2 on RHEL 9 intermittently spits out this message to no apparent effect on our tests
             Pattern.compile(".*time=.*level=warning.*msg=.*S.gpg-agent.*since it is a socket.*"),
             // org.jfree.jfreesvg reflectively accesses com.orsoncharts.Chart3DHints which is not on the classpath
-            Pattern.compile("Warning: Could not resolve com.orsoncharts.Chart3DHints for reflection configuration. Reason: java.lang.ClassNotFoundException: com.orsoncharts.Chart3DHints.")
+            Pattern.compile("Warning: Could not resolve .*com.orsoncharts.Chart3DHints for reflection configuration. Reason: java.lang.ClassNotFoundException: com.orsoncharts.Chart3DHints.")
     }),
 
     QUARKUS_FULL_MICROPROFILE(new Pattern[]{


### PR DESCRIPTION
On GraalVM 23.x the warning includes `[...] resolve class[...]` over `[...] resolve com.orsoncharts[...]` in the message which the test didn't expect. Example warning on 23.x:

```
Warning: Could not resolve class com.orsoncharts.Chart3DHints for reflection configuration. Reason: java.lang.ClassNotFoundException: com.orsoncharts.Chart3DHints.
```