### PR TITLE
Q 999-SNAPSHOT needs GIT SHA in report

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/PerfCheckTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/PerfCheckTest.java
@@ -101,7 +101,8 @@ public class PerfCheckTest {
     public static Map<String, String> populateHeader(Map<String, String> report) {
         report.put("arch", getProperty("perf.app.arch", System.getProperty("os.arch")));
         report.put("os", getProperty("perf.app.os", System.getProperty("os.name")));
-        report.put("quarkusVersion", QUARKUS_VERSION.getVersionString());
+        report.put("quarkusVersion", QUARKUS_VERSION.isSnapshot() ?
+                QUARKUS_VERSION.getGitSHA() + '.' + QUARKUS_VERSION.getVersionString() : QUARKUS_VERSION.getVersionString());
         report.put("mandrelVersion", UsedVersion.getVersion(false).toString());
         report.put("jdkVersion", String.format("%s.%s.%s", UsedVersion.jdkFeature(false),
                 UsedVersion.jdkInterim(false), UsedVersion.jdkUpdate(false)));

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/Commands.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/Commands.java
@@ -85,7 +85,7 @@ public class Commands {
 
     public static final String GRAALVM_BUILD_OUTPUT_JSON_FILE = "<GRAALVM_BUILD_OUTPUT_JSON_FILE>";
     public static final String GRAALVM_BUILD_OUTPUT_JSON_FILE_SWITCH = "-H:BuildOutputJSONFile=";
-    public static final QuarkusVersion QUARKUS_VERSION = new QuarkusVersion(getProperty("QUARKUS_VERSION", "2.13.7.Final"));
+    public static final QuarkusVersion QUARKUS_VERSION = new QuarkusVersion();
     public static final String BUILDER_IMAGE = getProperty("QUARKUS_NATIVE_BUILDER-IMAGE", "quay.io/quarkus/ubi-quarkus-mandrel-builder-image:22.3-java17");
 
     public static String getProperty(String key) {

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/QuarkusVersion.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/QuarkusVersion.java
@@ -19,6 +19,8 @@
  */
 package org.graalvm.tests.integration.utils.versions;
 
+import static org.graalvm.tests.integration.utils.Commands.getProperty;
+
 public class QuarkusVersion implements Comparable<QuarkusVersion> {
 
     private final String version;
@@ -26,6 +28,11 @@ public class QuarkusVersion implements Comparable<QuarkusVersion> {
     private final int minor;
     private final int patch;
     private final boolean snapshot;
+    private final String gitSHA;
+
+    public QuarkusVersion() {
+        this(getProperty("QUARKUS_VERSION", "2.13.7.Final"));
+    }
 
     public QuarkusVersion(String version) {
         this.version = version;
@@ -34,11 +41,13 @@ public class QuarkusVersion implements Comparable<QuarkusVersion> {
             this.major = Integer.parseInt(version.split("-")[0]);
             this.minor = 0;
             this.patch = 0;
+            this.gitSHA = getProperty("QUARKUS_VERSION_GITSHA", "");
         } else {
-            String[] split = version.split("\\.");
+            final String[] split = version.split("\\.");
             this.major = Integer.parseInt(split[0]);
             this.minor = Integer.parseInt(split[1]);
             this.patch = Integer.parseInt(split[2]);
+            this.gitSHA = null;
         }
     }
 
@@ -79,6 +88,10 @@ public class QuarkusVersion implements Comparable<QuarkusVersion> {
 
     public String getVersionString() {
         return version;
+    }
+
+    public String getGitSHA() {
+        return gitSHA;
     }
 
     @Override


### PR DESCRIPTION
fixes #135 

It works as expected, I have this in DB now:

![screenshot](https://user-images.githubusercontent.com/691097/218668435-18d28332-1e5b-4cf9-aed1-9ecefd5de073.png)
