### PR TITLE
For now disable upstream's debug info stripping.

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildAndRunCmds.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildAndRunCmds.java
@@ -28,6 +28,7 @@ import static org.graalvm.tests.integration.PerfCheckTest.MX_HEAP_MB;
 import static org.graalvm.tests.integration.utils.Commands.BUILDER_IMAGE;
 import static org.graalvm.tests.integration.utils.Commands.CONTAINER_RUNTIME;
 import static org.graalvm.tests.integration.utils.Commands.GRAALVM_BUILD_OUTPUT_JSON_FILE;
+import static org.graalvm.tests.integration.utils.Commands.GRAALVM_STRIP_DEBUG_DISABLE;
 import static org.graalvm.tests.integration.utils.Commands.IS_THIS_WINDOWS;
 import static org.graalvm.tests.integration.utils.Commands.QUARKUS_VERSION;
 import static org.graalvm.tests.integration.utils.Commands.getUnixUIDGID;
@@ -61,7 +62,8 @@ public enum BuildAndRunCmds {
                     "-Dquarkus.native.additional-build-args=" +
                             "-H:Log=registerResource:," +
                             "--trace-object-instantiation=java.util.Random," +
-                            "--initialize-at-run-time=io.vertx.ext.auth.impl.jose.JWT"
+                            "--initialize-at-run-time=io.vertx.ext.auth.impl.jose.JWT" +
+                            GRAALVM_STRIP_DEBUG_DISABLE
             },
             new String[]{"mvn", "dependency:sources", "-Dquarkus.version=" + QUARKUS_VERSION.getVersionString()},
             new String[]{IS_THIS_WINDOWS ? "target\\quarkus-runner.exe" : "./target/quarkus-runner"}

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/Commands.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/Commands.java
@@ -85,6 +85,8 @@ public class Commands {
 
     public static final String GRAALVM_BUILD_OUTPUT_JSON_FILE = "<GRAALVM_BUILD_OUTPUT_JSON_FILE>";
     public static final String GRAALVM_BUILD_OUTPUT_JSON_FILE_SWITCH = "-H:BuildOutputJSONFile=";
+    public static final String GRAALVM_STRIP_DEBUG_DISABLE = "<GRAALVM_DISABLE_STRIP_DEBUG>";
+    public static final String GRAALVM_STRIP_DEBUG_DISABLE_SWITCH = "-H:-StripDebugInfo";
     public static final QuarkusVersion QUARKUS_VERSION = new QuarkusVersion();
     public static final String BUILDER_IMAGE = getProperty("QUARKUS_NATIVE_BUILDER-IMAGE", "quay.io/quarkus/ubi-quarkus-mandrel-builder-image:22.3-java17");
 


### PR DESCRIPTION
This avoids trying to add a debuglink to the resulting binary twice which then fails the CRC check when reading the debuginfo.

Closes #138