### PR TITLE
Fix imageio integration tests for 23+

### DIFF
--- a/apps/imageio/src/main/java/imageio/Main.java
+++ b/apps/imageio/src/main/java/imageio/Main.java
@@ -206,16 +206,18 @@ public class Main {
         String fs = File.separator;
         String dir = userDir + fs + ".java" + fs + "fonts" + fs + version;
         Path fontsCacheDir = Paths.get(dir);
-        try {
-            Files.walkFileTree(fontsCacheDir, new SimpleFileVisitor<Path>() {
-                @Override
-                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                    Files.delete(file);
-                    return FileVisitResult.CONTINUE;
-                }
-            });
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to remove fonts config cache file", e);
+        if (Files.exists(fontsCacheDir)) { // May not exist for container builds
+            try {
+                Files.walkFileTree(fontsCacheDir, new SimpleFileVisitor<Path>() {
+                    @Override
+                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                        Files.delete(file);
+                        return FileVisitResult.CONTINUE;
+                    }
+                });
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to remove fonts config cache file", e);
+            }
         }
     }
 }

--- a/apps/imageio/src/main/java/imageio/Main.java
+++ b/apps/imageio/src/main/java/imageio/Main.java
@@ -61,7 +61,7 @@ import static java.awt.image.BufferedImage.TYPE_BYTE_BINARY;
 // $ jar uf target/imageio.jar -C src/main/resources/ META-INF
 // $ native-image -H:IncludeResources=Grace_M._Hopper.jp2,MyFreeMono.ttf,MyFreeSerif.ttf --no-fallback -jar target/imageio.jar target/imageio
 // $ rm -rf mytest*
-// $ ./target/imageio -Djava.home=$(pwd)
+// $ ./target/imageio -Djava.awt.headless=true -Djava.home=$(pwd)
 public class Main {
 
     /**

--- a/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
@@ -21,6 +21,7 @@ package org.graalvm.tests.integration;
 
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
+import org.graalvm.home.Version;
 import org.graalvm.tests.integration.utils.Apps;
 import org.graalvm.tests.integration.utils.LogBuilder;
 import org.graalvm.tests.integration.utils.Logs;
@@ -596,6 +597,17 @@ public class AppReproducersTest {
             // Test static libs in the executable
             final File executable = new File(appDir.getAbsolutePath() + File.separator + "target", "imageio");
             Set<String> expected = Set.of("libawt.a", "libawt_headless.a", "libfdlibm.a", "libfontmanager.a", "libjava.a", "libjavajpeg.a", "libjvm.a", "liblcms.a", "liblibchelper.a", "libnet.a", "libnio.a", "libzip.a");
+            if (UsedVersion.getVersion(inContainer).compareTo(Version.parse("23.0")) >= 0) {
+                // The set of static libs for imageio is smaller beginning with Mandrel 23+ as
+                // it has dynamic AWT support.
+                Set<String> modifiable = new HashSet<>(expected);
+                modifiable.remove("libawt_headless.a");
+                modifiable.remove("libfontmanager.a");
+                modifiable.remove("libjavajpeg.a");
+                modifiable.remove("liblcms.a");
+                modifiable.remove("libawt.a");
+                expected = Collections.unmodifiableSet(modifiable);
+            }
             if (UsedVersion.jdkFeature(inContainer) > 11 || (UsedVersion.jdkFeature(inContainer) == 11 && UsedVersion.jdkUpdate(inContainer) > 12)) {
                 // Harfbuzz removed: https://github.com/graalvm/mandrel/issues/286
                 // NO-OP

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildAndRunCmds.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildAndRunCmds.java
@@ -168,7 +168,7 @@ public enum BuildAndRunCmds {
             new String[]{"java", "-Djava.awt.headless=true", "-agentlib:native-image-agent=config-output-dir=src/main/resources/META-INF/native-image", "-jar", "target/imageio.jar"},
             new String[]{"jar", "uf", "target/imageio.jar", "-C", "src/main/resources/", "META-INF"},
             new String[]{"native-image", "-J-Djava.awt.headless=true", "-H:IncludeResources=Grace_M._Hopper.jp2,MyFreeMono.ttf,MyFreeSerif.ttf", "--no-fallback", "-jar", "target/imageio.jar", "target/imageio"},
-            new String[]{IS_THIS_WINDOWS ? "target\\imageio.exe" : "./target/imageio"}
+            new String[]{IS_THIS_WINDOWS ? "target\\imageio.exe" : "./target/imageio", "-Djava.home=.", "-Djava.awt.headless=true"}
     }),
     IMAGEIO_BUILDER_IMAGE(new String[][]{
             // Bring Your Own Maven (not a part of the builder image toolchain)

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildAndRunCmds.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildAndRunCmds.java
@@ -191,11 +191,11 @@ public enum BuildAndRunCmds {
                     "-J-Djava.awt.headless=true", "-H:IncludeResources=Grace_M._Hopper.jp2,MyFreeMono.ttf,MyFreeSerif.ttf", "--no-fallback", "-jar", "target/imageio.jar", "target/imageio"},
             // We build a runtime image, ubi 8 minimal based, runtime dependencies installed
             new String[]{CONTAINER_RUNTIME, "build", "--network=host", "-t", ContainerNames.IMAGEIO_BUILDER_IMAGE.name, "."},
-            // We have to run int the same env as we run the java part above, i.e. in the same container base.
+            // We have to run in the same env as we run the java part above, i.e. in the same container base.
             // Hashsums of font rotations would differ otherwise as your linux host might have different freetype native libs.
             new String[]{CONTAINER_RUNTIME, "run", IS_THIS_WINDOWS ? "" : "-u", IS_THIS_WINDOWS ? "" : getUnixUIDGID(),
                     "-t", "-v", BASE_DIR + File.separator + "apps" + File.separator + "imageio:/work:z",
-                    ContainerNames.IMAGEIO_BUILDER_IMAGE.name, "/work/target/imageio"}
+                    ContainerNames.IMAGEIO_BUILDER_IMAGE.name, "/work/target/imageio", "-Djava.home=.", "-Djava.awt.headless=true"}
     }),
     DEBUG_SYMBOLS_SMOKE(new String[][]{
             new String[]{"mvn", "package"},

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
@@ -46,7 +46,9 @@ public enum WhitelistLogLines {
 
     IMAGEIO(new Pattern[]{
             // org.jfree.jfreesvg reflectively accesses com.orsoncharts.Chart3DHints which is not on the classpath
-            Pattern.compile("Warning: Could not resolve .*com.orsoncharts.Chart3DHints for reflection configuration. Reason: java.lang.ClassNotFoundException: com.orsoncharts.Chart3DHints.")
+            Pattern.compile("Warning: Could not resolve .*com.orsoncharts.Chart3DHints for reflection configuration. Reason: java.lang.ClassNotFoundException: com.orsoncharts.Chart3DHints."),
+            // The java agent erronously produces a reflect config mentioning this constructor, which doesn't exist
+            Pattern.compile("Warning: Method sun\\.security\\.provider\\.NativePRNG\\.<init>\\(SecureRandomParameters\\) not found.")
     }),
 
     IMAGEIO_BUILDER_IMAGE(new Pattern[]{


### PR DESCRIPTION
Please review this fix for the imageio integration tests so
that they work for 23+ GraalVM as well. The changes are
fairly minimal. Basically setting `java.home` property for
the native run and cleaning the font cache prior running
java with the native agent and prior running natively
(for symmetry).

Thoughts?

Closes: #143 