### PR TITLE
Adds fake JAVA_HOME to appease FontConfig

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
@@ -551,6 +551,12 @@ public class AppReproducersTest {
             controlData.keySet().forEach(f -> new File(appDir, f).delete());
 
             LOGGER.info("Running...");
+
+            // Fontconfig might look for fonts here, see similar thing in Quarkus:
+            // https://github.com/quarkusio/quarkus/blob/main/extensions/awt/runtime/src/main/java/io/quarkus/awt/runtime/JDKSubstitutions.java#L53
+            // Details: https://github.com/Karm/mandrel-integration-tests/issues/151#issuecomment-1516802244
+            Files.createDirectories(Path.of(appDir.toString(), "lib")).toFile().deleteOnExit();
+
             final List<String> cmd = getRunCommand(app.buildAndRunCmds.cmds[app.buildAndRunCmds.cmds.length - 1]);
             process = runCommand(cmd, appDir, processLog, app);
             assertNotNull(process, "The test application failed to run. Check " + getLogsDir(cn, mn) + File.separator + processLog.getName());

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
@@ -47,7 +47,7 @@ public enum WhitelistLogLines {
     IMAGEIO(new Pattern[]{
             // org.jfree.jfreesvg reflectively accesses com.orsoncharts.Chart3DHints which is not on the classpath
             Pattern.compile("Warning: Could not resolve .*com.orsoncharts.Chart3DHints for reflection configuration. Reason: java.lang.ClassNotFoundException: com.orsoncharts.Chart3DHints."),
-            // The java agent erronously produces a reflect config mentioning this constructor, which doesn't exist
+            // The java agent erroneously produces a reflection config mentioning this constructor, which doesn't exist
             Pattern.compile("Warning: Method sun\\.security\\.provider\\.NativePRNG\\.<init>\\(SecureRandomParameters\\) not found.")
     }),
 
@@ -57,7 +57,9 @@ public enum WhitelistLogLines {
             // Podman with cgroupv2 on RHEL 9 intermittently spits out this message to no apparent effect on our tests
             Pattern.compile(".*time=.*level=warning.*msg=.*S.gpg-agent.*since it is a socket.*"),
             // org.jfree.jfreesvg reflectively accesses com.orsoncharts.Chart3DHints which is not on the classpath
-            Pattern.compile("Warning: Could not resolve .*com.orsoncharts.Chart3DHints for reflection configuration. Reason: java.lang.ClassNotFoundException: com.orsoncharts.Chart3DHints.")
+            Pattern.compile("Warning: Could not resolve .*com.orsoncharts.Chart3DHints for reflection configuration. Reason: java.lang.ClassNotFoundException: com.orsoncharts.Chart3DHints."),
+            // The java agent erroneously produces a reflection config mentioning this constructor, which doesn't exist
+            Pattern.compile("Warning: Method sun\\.security\\.provider\\.NativePRNG\\.<init>\\(SecureRandomParameters\\) not found.")
     }),
 
     QUARKUS_FULL_MICROPROFILE(new Pattern[]{


### PR DESCRIPTION
It works both locally:

```
mvn clean verify -Ptestsuite -Dtest=AppReproducersTest#imageioAWTTest
```
and in a container:

```
mvn clean verify -Ptestsuite-builder-image -Dtest=AppReproducersTest#imageioAWTContainerTest -Dquarkus.native.builder-image=quay.io/karmkarm/ubi-quarkus-mandrel-builder-image:23.0-java20
```

How come it works in the container without creating those JAVA_HOME dirs in the container and copying .so files there?
It's because the TS mounts the app dir, parent o the target dir:

```
docker run -u 1000:1000 -t -v /home/karm/workspaceRH/mandrel-integration-tests-Apr2023/apps/imageio:/work:z my-imageio-runner /work/target/imageio -Djava.home=. -Djava.awt.headless=true
```