### PR TITLE
Show version in gdb should return text including `gdb`

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/GDBSession.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/GDBSession.java
@@ -272,7 +272,7 @@ public enum GDBSession {
         }
     };
 
-    private static final CP SHOW_VERSION = new CP("show version\n", Pattern.compile(".*", Pattern.DOTALL));
+    private static final CP SHOW_VERSION = new CP("show version\n", Pattern.compile(".*gdb.*", Pattern.DOTALL));
 
     public abstract CP[] get(boolean inContainer);
 }


### PR DESCRIPTION
Waiting for `.*` results in essentially matching no output as well, which is not intended.

Fixes: #157