### PR TITLE
Update flags for DebugSymbolsSmoke test for GraalVM 23.0 as well

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
@@ -56,8 +56,8 @@ import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.graalvm.tests.integration.DebugSymbolsTest.DebugOptions.TrackNodeSourcePosition_23_0;
-import static org.graalvm.tests.integration.DebugSymbolsTest.DebugOptions.DebugCodeInfoUseSourceMappings_23_1;
-import static org.graalvm.tests.integration.DebugSymbolsTest.DebugOptions.OmitInlinedMethodDebugLineInfo_23_1;
+import static org.graalvm.tests.integration.DebugSymbolsTest.DebugOptions.DebugCodeInfoUseSourceMappings_23_0;
+import static org.graalvm.tests.integration.DebugSymbolsTest.DebugOptions.OmitInlinedMethodDebugLineInfo_23_0;
 import static org.graalvm.tests.integration.utils.Commands.builderRoutine;
 import static org.graalvm.tests.integration.utils.Commands.cleanTarget;
 import static org.graalvm.tests.integration.utils.Commands.cleanup;
@@ -846,21 +846,16 @@ public class AppReproducersTest {
 
             Map<String, String> switches;
             Version version = UsedVersion.getVersion(app.runtimeContainer != ContainerNames.NONE);
-            if (version.compareTo(Version.create(23, 1, 0)) >= 0) {
+            if (version.compareTo(Version.create(23, 0, 0)) >= 0) {
                 switches = Map.of(
                         TrackNodeSourcePosition_23_0.token, TrackNodeSourcePosition_23_0.replacement,
-                        DebugCodeInfoUseSourceMappings_23_1.token, DebugCodeInfoUseSourceMappings_23_1.replacement,
-                        OmitInlinedMethodDebugLineInfo_23_1.token, OmitInlinedMethodDebugLineInfo_23_1.replacement);
-            } else if (version.compareTo(Version.create(23, 0, 0)) >= 0) {
-                switches = Map.of(
-                        TrackNodeSourcePosition_23_0.token, TrackNodeSourcePosition_23_0.replacement,
-                        DebugCodeInfoUseSourceMappings_23_1.token, "",
-                        OmitInlinedMethodDebugLineInfo_23_1.token, "");
+                        DebugCodeInfoUseSourceMappings_23_0.token, DebugCodeInfoUseSourceMappings_23_0.replacement,
+                        OmitInlinedMethodDebugLineInfo_23_0.token, OmitInlinedMethodDebugLineInfo_23_0.replacement);
             } else {
                 switches = Map.of(
                         TrackNodeSourcePosition_23_0.token, "",
-                        DebugCodeInfoUseSourceMappings_23_1.token, "",
-                        OmitInlinedMethodDebugLineInfo_23_1.token, "");
+                        DebugCodeInfoUseSourceMappings_23_0.token, "",
+                        OmitInlinedMethodDebugLineInfo_23_0.token, "");
             }
             // In this case, the two last commands are used for running the app; one in JVM mode and the other in Native mode.
             // We should somehow capture this semantically in an Enum or something. This is fragile...

--- a/testsuite/src/it/java/org/graalvm/tests/integration/DebugSymbolsTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/DebugSymbolsTest.java
@@ -52,8 +52,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static org.graalvm.tests.integration.DebugSymbolsTest.DebugOptions.TrackNodeSourcePosition_23_0;
-import static org.graalvm.tests.integration.DebugSymbolsTest.DebugOptions.DebugCodeInfoUseSourceMappings_23_1;
-import static org.graalvm.tests.integration.DebugSymbolsTest.DebugOptions.OmitInlinedMethodDebugLineInfo_23_1;
+import static org.graalvm.tests.integration.DebugSymbolsTest.DebugOptions.DebugCodeInfoUseSourceMappings_23_0;
+import static org.graalvm.tests.integration.DebugSymbolsTest.DebugOptions.OmitInlinedMethodDebugLineInfo_23_0;
 import static org.graalvm.tests.integration.utils.Commands.CONTAINER_RUNTIME;
 import static org.graalvm.tests.integration.utils.Commands.QUARKUS_VERSION;
 import static org.graalvm.tests.integration.utils.Commands.builderRoutine;
@@ -86,9 +86,9 @@ public class DebugSymbolsTest {
     public static final String BASE_DIR = getBaseDir();
 
     public enum DebugOptions {
-        TrackNodeSourcePosition_23_0("<DEBUG_FLAGS_23_0>", "-H:+TrackNodeSourcePosition"),
-        DebugCodeInfoUseSourceMappings_23_1("<DEBUG_FLAGS_23_1_a>", "-H:+DebugCodeInfoUseSourceMappings"),
-        OmitInlinedMethodDebugLineInfo_23_1("<DEBUG_FLAGS_23_1_b>", "-H:+OmitInlinedMethodDebugLineInfo");
+        TrackNodeSourcePosition_23_0("<DEBUG_FLAGS_23_0_a>", "-H:+TrackNodeSourcePosition"),
+        DebugCodeInfoUseSourceMappings_23_0("<DEBUG_FLAGS_23_0_b>", "-H:+DebugCodeInfoUseSourceMappings"),
+        OmitInlinedMethodDebugLineInfo_23_0("<DEBUG_FLAGS_23_0_c>", "-H:+OmitInlinedMethodDebugLineInfo");
 
         public final String token;
         final String replacement;
@@ -120,21 +120,16 @@ public class DebugSymbolsTest {
 
             Map<String, String> switches;
             Version version = UsedVersion.getVersion(app.runtimeContainer != ContainerNames.NONE);
-            if (version.compareTo(Version.create(23, 1, 0)) >= 0) {
+            if (version.compareTo(Version.create(23, 0, 0)) >= 0) {
                 switches = Map.of(
                         TrackNodeSourcePosition_23_0.token, TrackNodeSourcePosition_23_0.replacement,
-                        DebugCodeInfoUseSourceMappings_23_1.token, DebugCodeInfoUseSourceMappings_23_1.replacement,
-                        OmitInlinedMethodDebugLineInfo_23_1.token, OmitInlinedMethodDebugLineInfo_23_1.replacement);
-            } else if (version.compareTo(Version.create(23, 0, 0)) >= 0) {
-                switches = Map.of(
-                        TrackNodeSourcePosition_23_0.token, TrackNodeSourcePosition_23_0.replacement,
-                        DebugCodeInfoUseSourceMappings_23_1.token, "",
-                        OmitInlinedMethodDebugLineInfo_23_1.token, "");
+                        DebugCodeInfoUseSourceMappings_23_0.token, DebugCodeInfoUseSourceMappings_23_0.replacement,
+                        OmitInlinedMethodDebugLineInfo_23_0.token, OmitInlinedMethodDebugLineInfo_23_0.replacement);
             } else {
                 switches = Map.of(
                         TrackNodeSourcePosition_23_0.token, "",
-                        DebugCodeInfoUseSourceMappings_23_1.token, "",
-                        OmitInlinedMethodDebugLineInfo_23_1.token, "");
+                        DebugCodeInfoUseSourceMappings_23_0.token, "",
+                        OmitInlinedMethodDebugLineInfo_23_0.token, "");
             }
             // In this case, the two last commands are used for running the app; one in JVM mode and the other in Native mode.
             // We should somehow capture this semantically in an Enum or something. This is fragile...

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildAndRunCmds.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildAndRunCmds.java
@@ -208,8 +208,8 @@ public enum BuildAndRunCmds {
                     
                     new String[]{"native-image", "-H:GenerateDebugInfo=1", "-H:+PreserveFramePointer", "-H:-DeleteLocalSymbols",
                             DebugSymbolsTest.DebugOptions.TrackNodeSourcePosition_23_0.token,
-                            DebugSymbolsTest.DebugOptions.DebugCodeInfoUseSourceMappings_23_1.token,
-                            DebugSymbolsTest.DebugOptions.OmitInlinedMethodDebugLineInfo_23_1.token,
+                            DebugSymbolsTest.DebugOptions.DebugCodeInfoUseSourceMappings_23_0.token,
+                            DebugSymbolsTest.DebugOptions.OmitInlinedMethodDebugLineInfo_23_0.token,
                             "-jar", "target/debug-symbols-smoke.jar", "target/debug-symbols-smoke"},
             new String[]{"java", "-jar", "./target/debug-symbols-smoke.jar"},
             new String[]{IS_THIS_WINDOWS ? "target\\debug-symbols-smoke.exe" : "./target/debug-symbols-smoke"}


### PR DESCRIPTION
New behaviour backported to 23.0 as well
https://github.com/oracle/graal/commit/eefeda1b94dd1a24aa6d1a557448a4e90d51c591

Relates to #154