### PR TITLE
Increase timeout for DebugSymbolsTest#debugSymbolsQuarkus

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/DebugSymbolsTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/DebugSymbolsTest.java
@@ -406,7 +406,7 @@ public class DebugSymbolsTest {
                         } else {
                             writer.write(cp.c);
                             writer.flush();
-                            boolean m = waitForBufferToMatch(stringBuffer, cp.p, 10, 1, TimeUnit.SECONDS);
+                            boolean m = waitForBufferToMatch(stringBuffer, cp.p, cp.timeoutSeconds, 1, TimeUnit.SECONDS);
                             Logs.appendlnSection(report, cp.c);
                             Logs.appendln(report, stringBuffer.toString());
                             if (!m) {

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/CP.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/CP.java
@@ -29,9 +29,17 @@ import java.util.regex.Pattern;
 public class CP {
     public final String c;
     public final Pattern p;
+    public final int timeoutSeconds;
 
     public CP(String c, Pattern p) {
         this.c = c;
         this.p = p;
+        this.timeoutSeconds = 10;
+    }
+
+    public CP(String c, Pattern p, int timeoutSeconds) {
+        this.c = c;
+        this.p = p;
+        this.timeoutSeconds = timeoutSeconds;
     }
 }

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/GDBSession.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/GDBSession.java
@@ -237,7 +237,10 @@ public enum GDBSession {
                     SHOW_VERSION,
                     new CP("b ConfigTestController.java:33\n",
                             Pattern.compile(".*Breakpoint 1 at .*: file com/example/quarkus/config/ConfigTestController.java, line 33.*",
-                                    Pattern.DOTALL)),
+                                    Pattern.DOTALL),
+                            // FIXME: The timeout should be revisited once we conclude on whether such a delay on loading
+                            // the symbols is acceptable or not. See https://github.com/Karm/mandrel-integration-tests/issues/160
+                            5 * 60),
                     new CP("run&\n",
                             Pattern.compile(".*Installed features:.*", Pattern.DOTALL)),
                     new CP("GOTO URL http://localhost:8080/data/config/lookup",


### PR DESCRIPTION
Increases timeout for setting breakpoint in `DebugSymbolsTest#debugSymbolsQuarkus`.

Avoids failures due to https://github.com/Karm/mandrel-integration-tests/issues/160

The timeout should be revisited once we conclude on whether such a delay on loading the symbols is acceptable or not.