### PR TITLE
Adjust timeouts for waiting GDB to read debug symbols

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/DebugSymbolsTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/DebugSymbolsTest.java
@@ -234,7 +234,7 @@ public class DebugSymbolsTest {
                 Logs.appendln(report, stringBuffer.toString());
                 assertTrue(waitForBufferToMatch(stringBuffer,
                                 Pattern.compile(".*Reading symbols from.*", Pattern.DOTALL),
-                                3000, 500, TimeUnit.MILLISECONDS),
+                                60000, 500, TimeUnit.MILLISECONDS),
                         "GDB session did not start well. Check the names, paths... Content was: " + stringBuffer.toString());
 
                 writer.write("set confirm off\n");

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/GDBSession.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/GDBSession.java
@@ -238,9 +238,7 @@ public enum GDBSession {
                     new CP("b ConfigTestController.java:33\n",
                             Pattern.compile(".*Breakpoint 1 at .*: file com/example/quarkus/config/ConfigTestController.java, line 33.*",
                                     Pattern.DOTALL),
-                            // FIXME: The timeout should be revisited once we conclude on whether such a delay on loading
-                            // the symbols is acceptable or not. See https://github.com/Karm/mandrel-integration-tests/issues/160
-                            10 * 60),
+                            60),
                     new CP("run&\n",
                             Pattern.compile(".*Installed features:.*", Pattern.DOTALL)),
                     new CP("GOTO URL http://localhost:8080/data/config/lookup",


### PR DESCRIPTION
https://github.com/oracle/graal/pull/6984 reduced the time spent reading debyg symbols but it's still noticeable. This PR re-adjusts the timeouts to a timeout of 60 seconds.

Relates to #160