### PR TITLE
Enhance gdb commands logging

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/DebugSymbolsTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/DebugSymbolsTest.java
@@ -157,12 +157,13 @@ public class DebugSymbolsTest {
             esvc.submit(reader);
 
             try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(process.getOutputStream()))) {
-                Logs.appendln(report, appDir.getAbsolutePath());
-                Logs.appendlnSection(report, String.join(" ", processBuilder.command()));
-                Logs.appendln(report, stringBuffer.toString());
-                assertTrue(waitForBufferToMatch(stringBuffer,
-                                Pattern.compile(".*Reading symbols from.*", Pattern.DOTALL),
-                                3000, 500, TimeUnit.MILLISECONDS),
+                Logs.appendlnSection(report, appDir.getAbsolutePath());
+                Logs.appendln(report, String.join(" ", processBuilder.command()));
+                boolean result = waitForBufferToMatch(report, stringBuffer,
+                        Pattern.compile(".*Reading symbols from.*", Pattern.DOTALL),
+                        3000, 500, TimeUnit.MILLISECONDS);
+                Logs.appendlnSection(report, stringBuffer.toString());
+                assertTrue(result,
                         "GDB session did not start well. Check the names, paths... Content was: " + stringBuffer.toString());
 
                 carryOutGDBSession(stringBuffer, GDBSession.DEBUG_SYMBOLS_SMOKE, esvc, writer, report, false);
@@ -226,15 +227,16 @@ public class DebugSymbolsTest {
             };
             esvc.submit(reader);
 
-            try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(process.getOutputStream()))) {
-                Logs.appendln(report, appDir.getAbsolutePath());
-                Logs.appendlnSection(report, String.join(" ", processBuilder.command()));
-                Logs.appendln(report, stringBuffer.toString());
-                assertTrue(waitForBufferToMatch(stringBuffer,
-                                Pattern.compile(".*Reading symbols from.*", Pattern.DOTALL),
-                                60000, 500, TimeUnit.MILLISECONDS),
-                        "GDB session did not start well. Check the names, paths... Content was: " + stringBuffer.toString());
+            Logs.appendlnSection(report, appDir.getAbsolutePath());
+            Logs.appendln(report, String.join(" ", processBuilder.command()));
+            boolean result = waitForBufferToMatch(report, stringBuffer,
+                    Pattern.compile(".*Reading symbols from.*", Pattern.DOTALL),
+                    60000, 500, TimeUnit.MILLISECONDS);
+            Logs.appendlnSection(report, stringBuffer.toString());
+            assertTrue(result,
+                    "GDB session did not start well. Check the names, paths... Content was: " + stringBuffer);
 
+            try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(process.getOutputStream()))) {
                 writer.write("set confirm off\n");
                 writer.flush();
 
@@ -335,13 +337,15 @@ public class DebugSymbolsTest {
             esvc.submit(reader);
 
             try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(gdbProcess.getOutputStream()))) {
-                Logs.appendln(report, appDir.getAbsolutePath());
-                Logs.appendlnSection(report, String.join(" ", processBuilder.command()));
-                Logs.appendln(report, stringBuffer.toString());
-                assertTrue(waitForBufferToMatch(stringBuffer,
-                                Pattern.compile(".*Reading symbols from.*", Pattern.DOTALL),
-                                3000, 500, TimeUnit.MILLISECONDS),
+                Logs.appendlnSection(report, appDir.getAbsolutePath());
+                Logs.appendln(report, String.join(" ", processBuilder.command()));
+                boolean result = waitForBufferToMatch(report, stringBuffer,
+                        Pattern.compile(".*Reading symbols from.*", Pattern.DOTALL),
+                        3000, 500, TimeUnit.MILLISECONDS);
+                Logs.appendlnSection(report, stringBuffer.toString());
+                assertTrue(result,
                         "GDB session did not start well. Check the names, paths... Content was: " + stringBuffer.toString());
+
 
                 writer.write("set confirm off\n");
                 writer.flush();
@@ -403,9 +407,9 @@ public class DebugSymbolsTest {
                         } else {
                             writer.write(cp.c);
                             writer.flush();
-                            boolean m = waitForBufferToMatch(stringBuffer, cp.p, cp.timeoutSeconds, 1, TimeUnit.SECONDS);
-                            Logs.appendlnSection(report, cp.c);
-                            Logs.appendln(report, stringBuffer.toString());
+                            Logs.appendln(report, cp.c);
+                            boolean m = waitForBufferToMatch(report, stringBuffer, cp.p, cp.timeoutSeconds, 1, TimeUnit.SECONDS);
+                            Logs.appendlnSection(report, stringBuffer.toString());
                             if (!m) {
                                 errorQueue.add("Command '" + cp.c.trim() + "' did not match the expected pattern '" +
                                         cp.p.pattern() + "'.\nOutput was:\n" + stringBuffer);

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/Commands.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/Commands.java
@@ -900,7 +900,7 @@ public class Commands {
         return -1;
     }
 
-    public static boolean waitForBufferToMatch(StringBuffer stringBuffer, Pattern pattern, long timeout, long sleep, TimeUnit unit) {
+    public static boolean waitForBufferToMatch(StringBuilder report, StringBuffer stringBuffer, Pattern pattern, long timeout, long sleep, TimeUnit unit) {
         long timeoutMillis = unit.toMillis(timeout);
         long sleepMillis = unit.toMillis(sleep);
         long startMillis = System.currentTimeMillis();
@@ -909,6 +909,7 @@ public class Commands {
             // To ensure the prompt appears consistently across gdb versions after every command we use the GDB/MI mode, i.e. the "--interpreter=mi" option.
             // See https://sourceware.org/gdb/onlinedocs/gdb/GDB_002fMI-Output-Syntax.html#GDB_002fMI-Output-Syntax
             if (Pattern.compile(".*\\(gdb\\).*", Pattern.DOTALL).matcher(stringBuffer.toString()).matches()) {
+                Logs.appendln(report, "Command took " + (System.currentTimeMillis() - startMillis) + " ms to complete");
                 return pattern.matcher(stringBuffer.toString()).matches();
             }
             try {
@@ -918,6 +919,7 @@ public class Commands {
                 Thread.currentThread().interrupt();
             }
         }
+        Logs.appendln(report, "Command timed out after " + (System.currentTimeMillis() - startMillis) + " ms");
         return false;
     }
 


### PR DESCRIPTION
1. Log output after waiting for the buffer to match the expected pattern (ensures log will contain the actual ouput)
2. Log the time it took for the buffer to match the expected pattern
3. Change the way log sections are used (include command and output in the same section)