### PR TITLE
Improve handling of gdb commands

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/Commands.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/Commands.java
@@ -905,8 +905,11 @@ public class Commands {
         long sleepMillis = unit.toMillis(sleep);
         long startMillis = System.currentTimeMillis();
         while (System.currentTimeMillis() - startMillis < timeoutMillis) {
-            if (pattern.matcher(stringBuffer.toString()).matches()) {
-                return true;
+            // Wait for command to complete, i.e. for the prompt to appear.
+            // To ensure the prompt appears consistently across gdb versions after every command we use the GDB/MI mode, i.e. the "--interpreter=mi" option.
+            // See https://sourceware.org/gdb/onlinedocs/gdb/GDB_002fMI-Output-Syntax.html#GDB_002fMI-Output-Syntax
+            if (Pattern.compile(".*\\(gdb\\).*", Pattern.DOTALL).matcher(stringBuffer.toString()).matches()) {
+                return pattern.matcher(stringBuffer.toString()).matches();
             }
             try {
                 Thread.sleep(sleepMillis);


### PR DESCRIPTION
Instead of waiting till the gdb output matches the expected command or timeouts, wait for the command to complete (or timeout), i.e. for the prompt to appear. This way if a command prints the expected output but doesn't complete, it's execution time is not being counted by the next `waitForBufferToMatch` invocation, additionally if the command completes but doesn't return the expected result we don't have to wait for the timeout. Furthermore, we can enhance the logging to see if the command timed out or completed but without matching the expected output.

To ensure the prompt appears consistently across gdb versions after every command we use the GDB/MI mode, i.e. the "--interpreter=mi" option.

Closes https://github.com/Karm/mandrel-integration-tests/issues/173