### PR TITLE
Smart getProperty(... was too smart with container runtime property

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/Commands.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/Commands.java
@@ -73,7 +73,7 @@ public class Commands {
 
     private static final Logger LOGGER = Logger.getLogger(Commands.class.getName());
 
-    public static final String CONTAINER_RUNTIME = getProperty("QUARKUS_NATIVE_CONTAINER_RUNTIME", "docker");
+    public static final String CONTAINER_RUNTIME = getProperty("QUARKUS_NATIVE_CONTAINER-RUNTIME", "docker");
     // Podman: Error: stats is not supported in rootless mode without cgroups v2
     public static final boolean PODMAN_WITH_SUDO = Boolean.parseBoolean(getProperty("PODMAN_WITH_SUDO", "true"));
     public static final boolean FAIL_ON_PERF_REGRESSION = Boolean.parseBoolean(getProperty("FAIL_ON_PERF_REGRESSION", "true"));


### PR DESCRIPTION
Regression caused by fed26dd, happens for some *podman* settings on command line, e.g. 
```
mvn clean verify -Ptestsuite-builder-image -Dquarkus.version=3.2.3.Final -Dquarkus.native.container-runtime=podman
```

must work too. Not just QUARKUS_NATIVE_CONTAINER_RUNTIME env prop.