### PR TITLE
Skip 21.3 testing in CI

### DIFF
--- a/.github/workflows/builder_image_tests.yml
+++ b/.github/workflows/builder_image_tests.yml
@@ -27,8 +27,6 @@ jobs:
       matrix:
         os: [ ubuntu-20.04 ]
         include:
-          - quarkus-version: '2.7.7.Final'
-            mandrel-builder-image: '21.3-java17'
           - quarkus-version: '2.13.8.Final'
             mandrel-builder-image: '22.3-java17'
           - quarkus-version: '2.16.9.Final'
@@ -51,7 +49,7 @@ jobs:
             ${{ matrix.quarkus-version }}-${{ matrix.os }}-
       - uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '17'
           check-latest: true
       - name: Linux test

--- a/.github/workflows/local_tests.yml
+++ b/.github/workflows/local_tests.yml
@@ -26,17 +26,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - quarkus-version: '2.7.7.Final'
-            mandrel-version: '21.3.6.0-Final'
-            java-version: '17'
-            os: 'windows-2019'
-            timeout-minutes: 80
-          - quarkus-version: '2.7.7.Final'
-            mandrel-version: '21.3.6.0-Final'
-            java-version: '17'
-            os: 'ubuntu-20.04'
-            timeout-minutes: 80
-
           - quarkus-version: '2.13.8.Final'
             mandrel-version: '22.3.3.1-Final'
             java-version: '17'


### PR DESCRIPTION
Also switch to `temurin` distro in setup-java. `adopt` is deprecated.