### PR TITLE
Disable versions test for 23.1+

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
@@ -788,6 +788,7 @@ public class AppReproducersTest {
 
     @Test
     @Tag("versions")
+    @IfMandrelVersion(max = "23.1") // Skip it for 23.1+. It has the graal-sdk split and mandrel no longer includes polyglot.jar
     public void versionsParsingMandrel(TestInfo testInfo) throws IOException, InterruptedException {
         final Apps app = Apps.VERSIONS;
         LOGGER.info("Testing app: " + app);


### PR DESCRIPTION
The graal-sdk split has, as a corollary, moved the HomeFinder API to the polyglot.jar artefact. Since Mandrel doesn't include this in a default install anymore, disable that test.

Closes: #182