### PR TITLE
Fix imageio test for 23.1+

### DIFF
--- a/apps/imageio/src/main/java/imageio/Main.java
+++ b/apps/imageio/src/main/java/imageio/Main.java
@@ -57,9 +57,9 @@ import static java.awt.image.BufferedImage.TYPE_BYTE_BINARY;
 
 // $ rm -rf src/main/resources/META-INF/* mytest* target
 // $ mvn clean package
-// $ java -agentlib:native-image-agent=config-output-dir=src/main/resources/META-INF/native-image -jar target/imageio.jar
+// $ java -Djava.awt.headless=true -agentlib:native-image-agent=config-output-dir=src/main/resources/META-INF/native-image -jar target/imageio.jar
 // $ jar uf target/imageio.jar -C src/main/resources/ META-INF
-// $ native-image -H:IncludeResources=Grace_M._Hopper.jp2,MyFreeMono.ttf,MyFreeSerif.ttf --no-fallback -jar target/imageio.jar target/imageio
+// $ native-image -J-Djava.awt.headless=true --no-fallback -jar target/imageio.jar target/imageio
 // $ rm -rf mytest*
 // $ ./target/imageio -Djava.awt.headless=true -Djava.home=$(pwd)
 public class Main {

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildAndRunCmds.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildAndRunCmds.java
@@ -169,7 +169,7 @@ public enum BuildAndRunCmds {
             new String[]{"mvn", "clean", "package"},
             new String[]{"java", "-Djava.awt.headless=true", "-agentlib:native-image-agent=config-output-dir=src/main/resources/META-INF/native-image", "-jar", "target/imageio.jar"},
             new String[]{"jar", "uf", "target/imageio.jar", "-C", "src/main/resources/", "META-INF"},
-            new String[]{"native-image", "-J-Djava.awt.headless=true", "-H:IncludeResources=Grace_M._Hopper.jp2,MyFreeMono.ttf,MyFreeSerif.ttf", "--no-fallback", "-jar", "target/imageio.jar", "target/imageio"},
+            new String[]{"native-image", "-J-Djava.awt.headless=true", "--no-fallback", "-jar", "target/imageio.jar", "target/imageio"},
             new String[]{IS_THIS_WINDOWS ? "target\\imageio.exe" : "./target/imageio", "-Djava.home=.", "-Djava.awt.headless=true"}
     }),
     IMAGEIO_BUILDER_IMAGE(new String[][]{
@@ -190,7 +190,7 @@ public enum BuildAndRunCmds {
             new String[]{CONTAINER_RUNTIME, "run", IS_THIS_WINDOWS ? "" : "-u", IS_THIS_WINDOWS ? "" : getUnixUIDGID(),
                     "-t", "-v", BASE_DIR + File.separator + "apps" + File.separator + "imageio:/project:z",
                     BUILDER_IMAGE,
-                    "-J-Djava.awt.headless=true", "-H:IncludeResources=Grace_M._Hopper.jp2,MyFreeMono.ttf,MyFreeSerif.ttf", "--no-fallback", "-jar", "target/imageio.jar", "target/imageio"},
+                    "-J-Djava.awt.headless=true", "--no-fallback", "-jar", "target/imageio.jar", "target/imageio"},
             // We build a runtime image, ubi 8 minimal based, runtime dependencies installed
             new String[]{CONTAINER_RUNTIME, "build", "--network=host", "-t", ContainerNames.IMAGEIO_BUILDER_IMAGE.name, "."},
             // We have to run in the same env as we run the java part above, i.e. in the same container base.


### PR DESCRIPTION
Resources don't need to get explicitly added with the CLI option, since the java run with the agent, will generate appropriate resource-config.json files which are sufficient for the resources to get added.

By removing `-H:IncludeResources` we no longer get the experimental VM warnings on 23.1+ (#186).