### PR TITLE
Allow list log lines for helidon

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
@@ -148,6 +148,9 @@ public enum WhitelistLogLines {
         @Override
         public Pattern[] get(boolean inContainer) {
             return new Pattern[]{
+                    // Experimental options not being unlocked, produces warnings, yet it's driven by the helidon-maven-plugin
+                    Pattern.compile(".*The option '.*' is experimental and must be enabled via '-H:\\+UnlockExperimentalVMOptions' in the future.*"),
+                    Pattern.compile(".*Please re-evaluate whether any experimental option is required, and either remove or unlock it.*"),
                     // Unused argument on new Graal
                     Pattern.compile(".*Ignoring server-mode native-image argument --no-server.*"),
                     // --allow-incomplete-classpath not available in new GraalVM https://github.com/Karm/mandrel-integration-tests/issues/76


### PR DESCRIPTION
The helidon native-image build is being driven by the helidon-maven-plugin which doesn't allow for unlocking certain parameters which the maven-plugin itself is adding. Therefore, allow list the newly produced warnings for now.

Closes: #189 