### PR TITLE
Fix version test exclusion

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
@@ -803,7 +803,7 @@ public class AppReproducersTest {
 
     @Test
     @Tag("versions")
-    @IfMandrelVersion(max = "23.1") // Skip it for 23.1+. It has the graal-sdk split and mandrel no longer includes polyglot.jar
+    @IfMandrelVersion(max = "23.0.99") // Skip it for 23.1+. It has the graal-sdk split and mandrel no longer includes polyglot.jar
     public void versionsParsingMandrel(TestInfo testInfo) throws IOException, InterruptedException {
         final Apps app = Apps.VERSIONS;
         LOGGER.info("Testing app: " + app);


### PR DESCRIPTION
The earlier fix missed to exclude 23.1 as the condition was 23.1.0.0-dev<sha> <= 23.1 which is true (wrong). What we actually want is to run it up to and including to 23.0. Latest release is 23.0.1, so up to a max value of 23.0 doesn't work either, since that would amount to 23.0.1 <= 23.0.0 which is false. Use 23.0.99 as the comparison value instead.