### PR TITLE
Temporary work around: Disable quarkus-full-microprofile dependent tests

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/DebugSymbolsTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/DebugSymbolsTest.java
@@ -25,6 +25,7 @@ import org.graalvm.tests.integration.utils.ContainerNames;
 import org.graalvm.tests.integration.utils.GDBSession;
 import org.graalvm.tests.integration.utils.Logs;
 import org.graalvm.tests.integration.utils.WebpageTester;
+import org.graalvm.tests.integration.utils.versions.IfQuarkusVersion;
 import org.graalvm.tests.integration.utils.versions.QuarkusVersion;
 import org.graalvm.tests.integration.utils.versions.UsedVersion;
 import org.jboss.logging.Logger;
@@ -206,6 +207,7 @@ public class DebugSymbolsTest {
     @Test
     @Tag("debugSymbolsQuarkus")
     @DisabledOnOs({OS.WINDOWS})
+    @IfQuarkusVersion(max = "3.5.999")
     public void debugSymbolsQuarkus(TestInfo testInfo) throws IOException, InterruptedException {
         final Apps app = Apps.DEBUG_QUARKUS_FULL_MICROPROFILE;
         LOGGER.info("Testing app: " + app);

--- a/testsuite/src/it/java/org/graalvm/tests/integration/PerfCheckTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/PerfCheckTest.java
@@ -27,6 +27,7 @@ import org.graalvm.tests.integration.utils.Logs;
 import org.graalvm.tests.integration.utils.Uploader;
 import org.graalvm.tests.integration.utils.WebpageTester;
 import org.graalvm.tests.integration.utils.versions.IfMandrelVersion;
+import org.graalvm.tests.integration.utils.versions.IfQuarkusVersion;
 import org.graalvm.tests.integration.utils.versions.UsedVersion;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.spi.HttpResponseCodes;
@@ -397,6 +398,7 @@ public class PerfCheckTest {
 
     @Test
     @IfMandrelVersion(min = "21.3")
+    @IfQuarkusVersion(max = "3.5.999")
     public void testQuarkusFullMicroProfile(TestInfo testInfo) throws IOException, InterruptedException, URISyntaxException {
         final Apps app = Apps.QUARKUS_FULL_MICROPROFILE_PERF;
         LOGGER.info("Testing app: " + app);

--- a/testsuite/src/it/java/org/graalvm/tests/integration/RuntimesSmokeTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/RuntimesSmokeTest.java
@@ -25,6 +25,7 @@ import org.graalvm.tests.integration.utils.ContainerNames;
 import org.graalvm.tests.integration.utils.LogBuilder;
 import org.graalvm.tests.integration.utils.Logs;
 import org.graalvm.tests.integration.utils.WebpageTester;
+import org.graalvm.tests.integration.utils.versions.IfQuarkusVersion;
 import org.graalvm.tests.integration.utils.versions.UsedVersion;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Assertions;
@@ -177,6 +178,7 @@ public class RuntimesSmokeTest {
 
     @Test
     @Tag("quarkus")
+    @IfQuarkusVersion(max = "3.5.999")
     public void quarkusFullMicroProfile(TestInfo testInfo) throws IOException, InterruptedException {
         Apps app = Apps.QUARKUS_FULL_MICROPROFILE;
         final Map<String, String> switches;

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/IfQuarkusVersion.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/IfQuarkusVersion.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023, Red Hat Inc. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.graalvm.tests.integration.utils.versions;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Closed interval from min to max.
+ * <p>
+ * e.g. closed interval [3.2.0, 3.6.1], as in 3.2.0 <= QUARKUS_VERSION <= 3.6.1
+ * translates to @IfQuarkusVersion(min = "3.2.0", max="3.6.1").
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(QuarkusVersionCondition.class)
+@Test
+public @interface IfQuarkusVersion {
+    String min() default "";
+
+    String max() default "";
+}

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/QuarkusVersionCondition.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/QuarkusVersionCondition.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023, Red Hat Inc. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.graalvm.tests.integration.utils.versions;
+
+import org.graalvm.tests.integration.utils.Commands;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.lang.reflect.AnnotatedElement;
+
+import static java.lang.String.format;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
+import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
+
+public class QuarkusVersionCondition implements ExecutionCondition {
+
+    private static final ConditionEvaluationResult ENABLED_BY_DEFAULT =
+            enabled("@IfQuarkusVersion is not present");
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(
+            ExtensionContext context) {
+        AnnotatedElement element = context
+                .getElement()
+                .orElseThrow(IllegalStateException::new);
+        return findAnnotation(element, IfQuarkusVersion.class)
+                .map(annotation -> disableIfVersionMismatch(annotation, element))
+                .orElse(ENABLED_BY_DEFAULT);
+    }
+
+    private ConditionEvaluationResult disableIfVersionMismatch(IfQuarkusVersion annotation, AnnotatedElement element) {
+        QuarkusVersion usedVersion = Commands.QUARKUS_VERSION;
+        final boolean quarkusConstraintSatisfied =
+                (annotation.min().isBlank() || usedVersion.compareTo(new QuarkusVersion(annotation.min())) >= 0) &&
+                        (annotation.max().isBlank() || usedVersion.compareTo(new QuarkusVersion(annotation.max())) <= 0);
+        if (quarkusConstraintSatisfied) {
+            return enabled(format(
+                    "%s is enabled as Quarkus version %s does satisfy constraints: min: %s, max: %s",
+                    element, usedVersion, annotation.min(), annotation.max()));
+        }
+        return disabled(format(
+                "%s is disabled as Quarkus version %s does not satisfy constraints: min: %s, max: %s",
+                element, usedVersion, annotation.min(), annotation.max()));
+    }
+}


### PR DESCRIPTION
Works around https://github.com/Karm/mandrel-integration-tests/issues/223 to get CI passing till it gets fixed.

One major drawback, other than the obvious one of skipping three good tests in Quarkus >= 3.6.0 is that we skip them for any SNAPSHOT build as well even for Quarkus < 3.6.0.