### PR TITLE
FullMicroprofile ported to new tracing API, MP6+ Q3.6+

### DIFF
--- a/apps/quarkus-full-microprofile/quarkus_3.6.x.patch
+++ b/apps/quarkus-full-microprofile/quarkus_3.6.x.patch
@@ -1,0 +1,247 @@
+diff --git a/apps/quarkus-full-microprofile/pom.xml b/apps/quarkus-full-microprofile/pom.xml
+index ce7df81..c047cd9 100644
+--- a/apps/quarkus-full-microprofile/pom.xml
++++ b/apps/quarkus-full-microprofile/pom.xml
+@@ -61,7 +61,7 @@
+         </dependency>
+         <dependency>
+             <groupId>io.quarkus</groupId>
+-            <artifactId>quarkus-smallrye-opentracing</artifactId>
++            <artifactId>quarkus-opentelemetry</artifactId>
+         </dependency>
+         <dependency>
+             <groupId>io.quarkus</groupId>
+diff --git a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/HelloController.java b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/HelloController.java
+index 0694ce6..88d552c 100644
+--- a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/HelloController.java
++++ b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/HelloController.java
+@@ -1,8 +1,8 @@
+ package com.example.quarkus;
+ 
+-import javax.inject.Singleton;
+-import javax.ws.rs.GET;
+-import javax.ws.rs.Path;
++import jakarta.inject.Singleton;
++import jakarta.ws.rs.GET;
++import jakarta.ws.rs.Path;
+ 
+ @Path("/hello")
+ @Singleton
+diff --git a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/QuarkusRestApplication.java b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/QuarkusRestApplication.java
+index 068ba12..410a130 100644
+--- a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/QuarkusRestApplication.java
++++ b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/QuarkusRestApplication.java
+@@ -1,7 +1,7 @@
+ package com.example.quarkus;
+ 
+-import javax.ws.rs.ApplicationPath;
+-import javax.ws.rs.core.Application;
++import jakarta.ws.rs.ApplicationPath;
++import jakarta.ws.rs.core.Application;
+ 
+ @ApplicationPath("/data")
+ public class QuarkusRestApplication extends Application {
+diff --git a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/client/ClientController.java b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/client/ClientController.java
+index 0f593eb..7360fcc 100644
+--- a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/client/ClientController.java
++++ b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/client/ClientController.java
+@@ -2,11 +2,11 @@ package com.example.quarkus.client;
+ 
+ import org.eclipse.microprofile.rest.client.inject.RestClient;
+ 
+-import javax.enterprise.context.ApplicationScoped;
+-import javax.inject.Inject;
+-import javax.ws.rs.GET;
+-import javax.ws.rs.Path;
+-import javax.ws.rs.PathParam;
++import jakarta.enterprise.context.ApplicationScoped;
++import jakarta.inject.Inject;
++import jakarta.ws.rs.GET;
++import jakarta.ws.rs.Path;
++import jakarta.ws.rs.PathParam;
+ 
+ @Path("/client")
+ @ApplicationScoped
+diff --git a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/client/Service.java b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/client/Service.java
+index ac9a4a5..35bcb99 100644
+--- a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/client/Service.java
++++ b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/client/Service.java
+@@ -2,10 +2,10 @@ package com.example.quarkus.client;
+ 
+ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+ 
+-import javax.enterprise.context.ApplicationScoped;
+-import javax.ws.rs.GET;
+-import javax.ws.rs.Path;
+-import javax.ws.rs.PathParam;
++import jakarta.enterprise.context.ApplicationScoped;
++import jakarta.ws.rs.GET;
++import jakarta.ws.rs.Path;
++import jakarta.ws.rs.PathParam;
+ 
+ @RegisterRestClient
+ @ApplicationScoped
+diff --git a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/client/ServiceController.java b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/client/ServiceController.java
+index 24a228d..6ec43f9 100644
+--- a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/client/ServiceController.java
++++ b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/client/ServiceController.java
+@@ -1,8 +1,8 @@
+ package com.example.quarkus.client;
+ 
+-import javax.ws.rs.GET;
+-import javax.ws.rs.Path;
+-import javax.ws.rs.PathParam;
++import jakarta.ws.rs.GET;
++import jakarta.ws.rs.Path;
++import jakarta.ws.rs.PathParam;
+ 
+ @Path("/client/service")
+ public class ServiceController {
+diff --git a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/config/ConfigTestController.java b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/config/ConfigTestController.java
+index 8119c23..517fe6f 100644
+--- a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/config/ConfigTestController.java
++++ b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/config/ConfigTestController.java
+@@ -4,10 +4,10 @@ import org.eclipse.microprofile.config.Config;
+ import org.eclipse.microprofile.config.ConfigProvider;
+ import org.eclipse.microprofile.config.inject.ConfigProperty;
+ 
+-import javax.enterprise.context.RequestScoped;
+-import javax.inject.Inject;
+-import javax.ws.rs.GET;
+-import javax.ws.rs.Path;
++import jakarta.enterprise.context.RequestScoped;
++import jakarta.inject.Inject;
++import jakarta.ws.rs.GET;
++import jakarta.ws.rs.Path;
+ 
+ /**
+  * !!! DO NOT TOUCH THE SOURCE WITHOUT EDITING GDBSession.java !!!
+diff --git a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/health/ServiceLiveHealthCheck.java b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/health/ServiceLiveHealthCheck.java
+index fea754c..d1ad0a6 100644
+--- a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/health/ServiceLiveHealthCheck.java
++++ b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/health/ServiceLiveHealthCheck.java
+@@ -4,7 +4,7 @@ import org.eclipse.microprofile.health.HealthCheck;
+ import org.eclipse.microprofile.health.HealthCheckResponse;
+ import org.eclipse.microprofile.health.Liveness;
+ 
+-import javax.enterprise.context.ApplicationScoped;
++import jakarta.enterprise.context.ApplicationScoped;
+ 
+ @Liveness
+ @ApplicationScoped
+diff --git a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/health/ServiceReadyHealthCheck.java b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/health/ServiceReadyHealthCheck.java
+index 6bb6374..cd7ac7a 100644
+--- a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/health/ServiceReadyHealthCheck.java
++++ b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/health/ServiceReadyHealthCheck.java
+@@ -4,7 +4,7 @@ import org.eclipse.microprofile.health.HealthCheck;
+ import org.eclipse.microprofile.health.HealthCheckResponse;
+ import org.eclipse.microprofile.health.Readiness;
+ 
+-import javax.enterprise.context.ApplicationScoped;
++import jakarta.enterprise.context.ApplicationScoped;
+ 
+ @Readiness
+ @ApplicationScoped
+diff --git a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/metric/MetricController.java b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/metric/MetricController.java
+index 1f4c2df..db4c9fa 100644
+--- a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/metric/MetricController.java
++++ b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/metric/MetricController.java
+@@ -6,10 +6,10 @@ import org.eclipse.microprofile.metrics.annotation.Gauge;
+ import org.eclipse.microprofile.metrics.annotation.Metric;
+ import org.eclipse.microprofile.metrics.annotation.Timed;
+ 
+-import javax.enterprise.context.ApplicationScoped;
+-import javax.inject.Inject;
+-import javax.ws.rs.GET;
+-import javax.ws.rs.Path;
++import jakarta.enterprise.context.ApplicationScoped;
++import jakarta.inject.Inject;
++import jakarta.ws.rs.GET;
++import jakarta.ws.rs.Path;
+ import java.util.Random;
+ 
+ @Path("/metric")
+diff --git a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/resilient/ResilienceController.java b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/resilient/ResilienceController.java
+index 04cf5fb..fc34f8e 100644
+--- a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/resilient/ResilienceController.java
++++ b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/resilient/ResilienceController.java
+@@ -3,9 +3,9 @@ package com.example.quarkus.resilient;
+ import org.eclipse.microprofile.faulttolerance.Fallback;
+ import org.eclipse.microprofile.faulttolerance.Timeout;
+ 
+-import javax.enterprise.context.ApplicationScoped;
+-import javax.ws.rs.GET;
+-import javax.ws.rs.Path;
++import jakarta.enterprise.context.ApplicationScoped;
++import jakarta.ws.rs.GET;
++import jakarta.ws.rs.Path;
+ 
+ @Path("/resilience")
+ @ApplicationScoped
+diff --git a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/secure/ProtectedController.java b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/secure/ProtectedController.java
+index 4447db7..1d54637 100644
+--- a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/secure/ProtectedController.java
++++ b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/secure/ProtectedController.java
+@@ -3,11 +3,11 @@ package com.example.quarkus.secure;
+ import org.eclipse.microprofile.jwt.Claim;
+ import org.eclipse.microprofile.jwt.ClaimValue;
+ 
+-import javax.annotation.security.RolesAllowed;
+-import javax.enterprise.context.RequestScoped;
+-import javax.inject.Inject;
+-import javax.ws.rs.GET;
+-import javax.ws.rs.Path;
++import jakarta.annotation.security.RolesAllowed;
++import jakarta.enterprise.context.RequestScoped;
++import jakarta.inject.Inject;
++import jakarta.ws.rs.GET;
++import jakarta.ws.rs.Path;
+ 
+ @Path("/protected")
+ @RequestScoped
+diff --git a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/secure/TestSecureController.java b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/secure/TestSecureController.java
+index fb82305..a95c3f0 100644
+--- a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/secure/TestSecureController.java
++++ b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/secure/TestSecureController.java
+@@ -5,14 +5,14 @@ import io.vertx.ext.auth.PubSecKeyOptions;
+ import io.vertx.ext.auth.jwt.JWTAuth;
+ import io.vertx.ext.auth.jwt.JWTAuthOptions;
+ 
+-import javax.annotation.PostConstruct;
+-import javax.enterprise.context.ApplicationScoped;
+-import javax.ws.rs.GET;
+-import javax.ws.rs.Path;
+-import javax.ws.rs.WebApplicationException;
+-import javax.ws.rs.client.ClientBuilder;
+-import javax.ws.rs.client.WebTarget;
+-import javax.ws.rs.core.Response;
++import jakarta.annotation.PostConstruct;
++import jakarta.enterprise.context.ApplicationScoped;
++import jakarta.ws.rs.GET;
++import jakarta.ws.rs.Path;
++import jakarta.ws.rs.WebApplicationException;
++import jakarta.ws.rs.client.ClientBuilder;
++import jakarta.ws.rs.client.WebTarget;
++import jakarta.ws.rs.core.Response;
+ import java.io.BufferedReader;
+ import java.io.IOException;
+ import java.io.InputStreamReader;
+diff --git a/apps/quarkus-full-microprofile/src/main/resources/application.properties b/apps/quarkus-full-microprofile/src/main/resources/application.properties
+index 30c3d85..aacd280 100644
+--- a/apps/quarkus-full-microprofile/src/main/resources/application.properties
++++ b/apps/quarkus-full-microprofile/src/main/resources/application.properties
+@@ -5,8 +5,10 @@ quarkus.ssl.native=true
+ mp.jwt.verify.publickey.location=META-INF/resources/publicKey.pem
+ mp.jwt.verify.issuer=https://server.example.com
+ quarkus.smallrye-jwt.enabled=true
+-quarkus.jaeger.service-name=Demo-Service-A
+-quarkus.jaeger.sampler-type=const
+-quarkus.jaeger.sampler-param=1
+-quarkus.jaeger.endpoint=http://localhost:14268/api/traces
++quarkus.otel.traces.exporter=cdi
++quarkus.otel.traces.sampler=parentbased_always_on
++quarkus.otel.traces.eusp.enabled=true
++quarkus.otel.service.name=Demo-Service-A
++quarkus.otel.exporter.otlp.endpoint=http://localhost:4317
++quarkus.otel.exporter.otlp.traces.endpoint=http://localhost:4317
+ quarkus.native.resources.includes=privateKey.pem

--- a/apps/quarkus-full-microprofile/threshold.properties
+++ b/apps/quarkus-full-microprofile/threshold.properties
@@ -1,6 +1,6 @@
 linux.time.to.first.ok.request.threshold.ms=300
 linux.RSS.threshold.kB=120000
-linux.executable.size.threshold.kB=73500
+linux.executable.size.threshold.kB=79000
 windows.time.to.first.ok.request.threshold.ms=1537
 windows.RSS.threshold.kB=120000
-windows.executable.size.threshold.kB=75000
+windows.executable.size.threshold.kB=79000

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/Logs.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/Logs.java
@@ -115,7 +115,7 @@ public class Logs {
                 long executableSizeThresholdKb = app.thresholdProperties.get(key);
                 assertThreshold(failures, executableSizeKb <= executableSizeThresholdKb,
                         "Application " + app + (mode != null ? " in mode " + mode : "") + " executable size " +
-                                ((mode == Mode.DIFF_JVM || mode == Mode.DIFF_NATIVE) ? "overhead is" : " is ") +
+                                ((mode == Mode.DIFF_JVM || mode == Mode.DIFF_NATIVE) ? "overhead is" : "is ") +
                                 executableSizeKb + " kB, which is over " +
                                 executableSizeThresholdKb + " kB threshold by " + percentageValOverTh(executableSizeKb, executableSizeThresholdKb) + "%.", false);
             } else {

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
@@ -41,6 +41,7 @@ public enum WhitelistLogLines {
                     Pattern.compile(".*maven-error-diagnostics.*"),
                     // Download https://repo.maven.apache.org/maven2/com/google/errorprone
                     Pattern.compile(".*com/google/errorprone/error_prone.*"),
+                    Pattern.compile(".*com.google.errorprone:error_prone_annotations:jar:sources.*"),
                     // JDK:
                     Pattern.compile("WARNING.* reflective access.*"),
                     Pattern.compile("WARNING: All illegal access operations.*"),
@@ -118,7 +119,9 @@ public enum WhitelistLogLines {
                     Pattern.compile(".*Warning: Could not register io.netty.* queryAllPublicMethods for reflection.*"),
                     // netty 4 which doesn't have the relevant native config in the lib. See https://github.com/netty/netty/pull/13596
                     Pattern.compile(".*Warning: The option '-H:ReflectionConfigurationResources=META-INF/native-image/io\\.netty/netty-transport/reflection-config\\.json' is experimental and must be enabled via.*"),
-                    Pattern.compile(".*Warning: Please re-evaluate whether any experimental option is required, and either remove or unlock it\\..*")
+                    Pattern.compile(".*Warning: Please re-evaluate whether any experimental option is required, and either remove or unlock it\\..*"),
+                    // We don't run any OpenTracing collector point for simplicity, hence the exception. Q 3.6.0+ specific.
+                    Pattern.compile(".*Failed to export spans. The request could not be executed. Full error message: Connection refused:.*")
             };
         }
     },


### PR DESCRIPTION
Fixes #225 

```
$ mvn clean verify -Ptestsuite 
-Dtest=RuntimesSmokeTest#quarkusFullMicroProfile,DebugSymbolsTest#debugSymbolsQuarkus,PerfCheckTest#testQuarkusFullMicroProfile 
-Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21 
-DincludeTags=runtimes,reproducers,perfcheck -Dquarkus.version=3.6.0 | tee log.log 

```

passes now.