### PR TITLE
Removed Mandrel 21 only test methods

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
@@ -789,14 +789,6 @@ public class AppReproducersTest {
     @Test
     @Tag("jdk-17")
     @Tag("recordannotations")
-    @IfMandrelVersion(min = "21.3.1.1", max = "21.3.999", minJDK = "17")
-    public void recordAnnotationsWork21_3(TestInfo testInfo) throws IOException, InterruptedException {
-        recordAnnotationsWork(testInfo);
-    }
-
-    @Test
-    @Tag("jdk-17")
-    @Tag("recordannotations")
     @IfMandrelVersion(min = "22.1", minJDK = "17")
     public void recordAnnotationsWorkPost22_1(TestInfo testInfo) throws IOException, InterruptedException {
         recordAnnotationsWork(testInfo);

--- a/testsuite/src/it/java/org/graalvm/tests/integration/StaticDistroChecks.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/StaticDistroChecks.java
@@ -52,12 +52,6 @@ public class StaticDistroChecks {
         spaceInPath(testInfo);
     }
 
-    @Test
-    @IfMandrelVersion(min = "21.3.3", max = "21.3.999")
-    public void spaceInPath_21(TestInfo testInfo) throws IOException {
-        spaceInPath(testInfo);
-    }
-
     public void spaceInPath(TestInfo testInfo) throws IOException {
         final Path graalHomeSpace = Path.of(System.getProperty("java.io.tmpdir"), "there are spaces");
         try {


### PR DESCRIPTION
Leaving resource locations there on purpose, it seems a neat way to see the difference over time.