### PR TITLE
Reintroduce Mandrel 21 sanity test

### DIFF
--- a/.github/workflows/builder_image_tests.yml
+++ b/.github/workflows/builder_image_tests.yml
@@ -27,6 +27,10 @@ jobs:
       matrix:
         os: [ ubuntu-20.04 ]
         include:
+          - quarkus-version: '2.13.3.Final'
+            mandrel-builder-image: '21.3-java11'
+          - quarkus-version: '2.13.3.Final'
+            mandrel-builder-image: '21.3-java17'
           - quarkus-version: '2.13.9.Final'
             mandrel-builder-image: '22.3-java17'
           - quarkus-version: '2.16.12.Final'

--- a/.github/workflows/local_tests.yml
+++ b/.github/workflows/local_tests.yml
@@ -26,6 +26,28 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - quarkus-version: '2.13.3.Final'
+            mandrel-version: '21.3.6.0-Final'
+            java-version: '11'
+            os: 'windows-2019'
+            timeout-minutes: 80
+          - quarkus-version: '2.13.3.Final'
+            mandrel-version: '21.3.6.0-Final'
+            java-version: '11'
+            os: 'ubuntu-20.04'
+            timeout-minutes: 80
+
+          - quarkus-version: '2.13.3.Final'
+            mandrel-version: '21.3.6.0-Final'
+            java-version: '17'
+            os: 'windows-2019'
+            timeout-minutes: 80
+          - quarkus-version: '2.13.3.Final'
+            mandrel-version: '21.3.6.0-Final'
+            java-version: '17'
+            os: 'ubuntu-20.04'
+            timeout-minutes: 80
+
           - quarkus-version: '2.13.9.Final'
             mandrel-version: '22.3.4.0-Final'
             java-version: '17'


### PR DESCRIPTION
It seems practical for certain parts of the TS to be able to run old Mandrel/Quarkus.
I will let this run the whole CI and then use annotations to restrict it only to parts where it makes sense, e.g. FullMicroProfile app.