### PR TITLE
Update whitelisted JFR log lines once more

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
@@ -202,19 +202,12 @@ public enum WhitelistLogLines {
                         Pattern.compile(".*Exception occurred when setting value \"150/s\" for class jdk.jfr.internal.Control.*")};
             } else {
                 return new Pattern[]{
-                        /* We don't support the new JFR Deprecated events annotation yet.
-                         * https://github.com/oracle/graal/commit/dd8eb7436ca2ce323a74667805dd7736c6ccc972 intercepts
-                         * related calls and throws VMErrors which are handled in JDK code,
-                         * and then get logged at runtime. Allow list those log lines until they are supported.
+                        /* We don't support the OldObjectSample event or the JFR Deprecated events annotation yet.
+                         * https://github.com/oracle/graal/pull/8057 intercepts calls to adjust settings related to
+                         * such events and instead logs a warning specific to SubstrateVM.
+                         * Allow list those log lines until they are supported.
                          */
-                        Pattern.compile(".*Exception occurred when setting value \"forRemoval\" for class jdk.jfr.internal.Control*"),
-                        /* We don't support the OldObjectSample event yet.
-                         * https://github.com/oracle/graal/commit/dd8eb7436ca2ce323a74667805dd7736c6ccc972 intercepts
-                         * calls to adjust OldObjectSample cutoff settings and throws VMErrors which are handled in
-                         * JDK code, and then get logged at runtime. Allow list those log lines until they are
-                         * supported.
-                         */
-                        Pattern.compile(".*Exception occurred when setting value \"0 ns\" for class jdk.jfr.internal.Control*"),
+                        Pattern.compile(".*@Deprecated JFR events, and leak profiling are not yet supported.*"),
                         // https://github.com/oracle/graal/issues/3636
                         Pattern.compile(".*Unable to commit. Requested size [0-9]* too large.*"),
                         // Hyperfoil spits this on GHA CI, cannot reproduce locally


### PR DESCRIPTION
This is a follow up to: https://github.com/Karm/mandrel-integration-tests/pull/238 

https://github.com/oracle/graal/pull/8037#event-11298904545 Has now been merged ([internal PR](https://github.com/oracle/graal/pull/8057)), so I've adjusted the whitelisted lines. 

This should prevent things form breaking when the latest JDK and GraalVM master are used. 
This PR replaces the old whitelisted lines. I'm not sure if that's the right thing to do (in case there is a test configuration that uses a development version that isn't the latest GraalVM master). I can add the old whitelisted lines back in if that's the case. 
