### PR TITLE
Update quarkus version checks to adapt to new SNAPSHOT versions

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/DebugSymbolsTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/DebugSymbolsTest.java
@@ -222,9 +222,9 @@ public class DebugSymbolsTest {
         final String cn = testInfo.getTestClass().get().getCanonicalName();
         final String mn = testInfo.getTestMethod().get().getName();
         final String patch;
-        if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.7.0")) >= 0) {
+        if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_7_0) >= 0) {
             patch = "quarkus_3.7.x.patch";
-        } else if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.6.0")) >= 0) {
+        } else if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_6_0) >= 0) {
             patch = "quarkus_3.6.x.patch";
         } else if (QUARKUS_VERSION.majorIs(3)) {
             patch = "quarkus_3.x.patch";
@@ -316,11 +316,8 @@ public class DebugSymbolsTest {
 
     // See https://github.com/quarkusio/quarkus/pull/20355
     private boolean applySourcesPatch() {
-        QuarkusVersion v224 = new QuarkusVersion("2.2.4");
-        QuarkusVersion v230 = new QuarkusVersion("2.3.0");
-        QuarkusVersion v240 = new QuarkusVersion("2.4.0");
-        return (QUARKUS_VERSION.compareTo(v224) >= 0 && QUARKUS_VERSION.compareTo(v230) < 0) ||
-                QUARKUS_VERSION.compareTo(v240) >= 0;
+        return (QUARKUS_VERSION.compareTo(QuarkusVersion.V_2_2_4) >= 0 && QUARKUS_VERSION.compareTo(QuarkusVersion.V_2_3_0) < 0) ||
+            QUARKUS_VERSION.compareTo(QuarkusVersion.V_2_4_0) >= 0;
     }
 
     @Test
@@ -347,7 +344,7 @@ public class DebugSymbolsTest {
             if (applySourcesPatch()) {
                 runCommand(getRunCommand("git", "apply", "quarkus_sources.patch"), appDir);
             }
-            if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.0.0")) >= 0) {
+            if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_0_0) >= 0) {
                 runCommand(getRunCommand("git", "apply", "quarkus_3.x.patch"), appDir);
             }
 
@@ -441,7 +438,7 @@ public class DebugSymbolsTest {
             if (applySourcesPatch()) {
                 runCommand(getRunCommand("git", "apply", "-R", "quarkus_sources.patch"), appDir);
             }
-            if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.0.0")) >= 0) {
+            if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_0_0) >= 0) {
                 runCommand(getRunCommand("git", "apply", "-R", "quarkus_3.x.patch"), appDir);
             }
         }

--- a/testsuite/src/it/java/org/graalvm/tests/integration/DebugSymbolsTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/DebugSymbolsTest.java
@@ -222,7 +222,7 @@ public class DebugSymbolsTest {
         final String cn = testInfo.getTestClass().get().getCanonicalName();
         final String mn = testInfo.getTestMethod().get().getName();
         final String patch;
-        if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.7.0")) >= 0 || QUARKUS_VERSION.isSnapshot()) {
+        if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.7.0")) >= 0) {
             patch = "quarkus_3.7.x.patch";
         } else if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.6.0")) >= 0) {
             patch = "quarkus_3.6.x.patch";
@@ -320,7 +320,7 @@ public class DebugSymbolsTest {
         QuarkusVersion v230 = new QuarkusVersion("2.3.0");
         QuarkusVersion v240 = new QuarkusVersion("2.4.0");
         return (QUARKUS_VERSION.compareTo(v224) >= 0 && QUARKUS_VERSION.compareTo(v230) < 0) ||
-                QUARKUS_VERSION.compareTo(v240) >= 0 || QUARKUS_VERSION.isSnapshot();
+                QUARKUS_VERSION.compareTo(v240) >= 0;
     }
 
     @Test
@@ -347,7 +347,7 @@ public class DebugSymbolsTest {
             if (applySourcesPatch()) {
                 runCommand(getRunCommand("git", "apply", "quarkus_sources.patch"), appDir);
             }
-            if (QUARKUS_VERSION.majorIs(3) || QUARKUS_VERSION.isSnapshot()) {
+            if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.0.0")) >= 0) {
                 runCommand(getRunCommand("git", "apply", "quarkus_3.x.patch"), appDir);
             }
 
@@ -441,10 +441,7 @@ public class DebugSymbolsTest {
             if (applySourcesPatch()) {
                 runCommand(getRunCommand("git", "apply", "-R", "quarkus_sources.patch"), appDir);
             }
-            if (QUARKUS_VERSION.isSnapshot()) {
-                runCommand(getRunCommand("git", "apply", "-R", "quarkus_snapshot.patch"), appDir);
-            }
-            if (QUARKUS_VERSION.majorIs(3) || QUARKUS_VERSION.isSnapshot()) {
+            if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.0.0")) >= 0) {
                 runCommand(getRunCommand("git", "apply", "-R", "quarkus_3.x.patch"), appDir);
             }
         }

--- a/testsuite/src/it/java/org/graalvm/tests/integration/PerfCheckTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/PerfCheckTest.java
@@ -139,7 +139,7 @@ public class PerfCheckTest {
             Files.createDirectories(Paths.get(appDir.getAbsolutePath(), "logs"));
             assertTrue(app.buildAndRunCmds.cmds.length > 1);
 
-            if (QUARKUS_VERSION.majorIs(3) || QUARKUS_VERSION.isSnapshot()) {
+            if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.0.0")) >= 0) {
                 runCommand(getRunCommand("git", "apply", "quarkus_3.x.patch"), appDir);
             }
 
@@ -245,7 +245,7 @@ public class PerfCheckTest {
                     "quarkus-json_+ParseOnce-native-image-source-jar", "quarkus-json_plus-ParseOnce.json").toFile());
             Logs.archiveLog(cn, mn, processLog);
             cleanTarget(app);
-            if (QUARKUS_VERSION.majorIs(3) || QUARKUS_VERSION.isSnapshot()) {
+            if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.0.0")) >= 0) {
                 runCommand(getRunCommand("git", "apply", "-R", "quarkus_3.x.patch"), appDir);
             }
         }
@@ -270,7 +270,7 @@ public class PerfCheckTest {
             Files.createDirectories(Paths.get(appDir.getAbsolutePath(), "logs"));
             assertTrue(app.buildAndRunCmds.cmds.length > 1);
 
-            if (QUARKUS_VERSION.majorIs(3) || QUARKUS_VERSION.isSnapshot()) {
+            if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.0.0")) >= 0) {
                 runCommand(getRunCommand("git", "apply", "quarkus_3.x.patch"), appDir);
             }
 
@@ -372,7 +372,7 @@ public class PerfCheckTest {
                     "quarkus-json-native-image-source-jar", "quarkus-json.json").toFile());
             Logs.archiveLog(cn, mn, processLog);
             cleanTarget(app);
-            if (QUARKUS_VERSION.majorIs(3) || QUARKUS_VERSION.isSnapshot()) {
+            if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.0.0")) >= 0) {
                 runCommand(getRunCommand("git", "apply", "-R", "quarkus_3.x.patch"), appDir);
             }
         }
@@ -390,7 +390,7 @@ public class PerfCheckTest {
         final String mn = testInfo.getTestMethod().get().getName();
         final List<Map<String, String>> reports = new ArrayList<>(2);
         final String patch;
-        if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.7.0")) >= 0 || QUARKUS_VERSION.isSnapshot()) {
+        if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.7.0")) >= 0) {
             patch = "quarkus_3.7.x.patch";
         } else if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.6.0")) >= 0) {
             patch = "quarkus_3.6.x.patch";

--- a/testsuite/src/it/java/org/graalvm/tests/integration/PerfCheckTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/PerfCheckTest.java
@@ -139,7 +139,7 @@ public class PerfCheckTest {
             Files.createDirectories(Paths.get(appDir.getAbsolutePath(), "logs"));
             assertTrue(app.buildAndRunCmds.cmds.length > 1);
 
-            if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.0.0")) >= 0) {
+            if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_0_0) >= 0) {
                 runCommand(getRunCommand("git", "apply", "quarkus_3.x.patch"), appDir);
             }
 
@@ -245,7 +245,7 @@ public class PerfCheckTest {
                     "quarkus-json_+ParseOnce-native-image-source-jar", "quarkus-json_plus-ParseOnce.json").toFile());
             Logs.archiveLog(cn, mn, processLog);
             cleanTarget(app);
-            if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.0.0")) >= 0) {
+            if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_0_0) >= 0) {
                 runCommand(getRunCommand("git", "apply", "-R", "quarkus_3.x.patch"), appDir);
             }
         }
@@ -270,7 +270,7 @@ public class PerfCheckTest {
             Files.createDirectories(Paths.get(appDir.getAbsolutePath(), "logs"));
             assertTrue(app.buildAndRunCmds.cmds.length > 1);
 
-            if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.0.0")) >= 0) {
+            if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_0_0) >= 0) {
                 runCommand(getRunCommand("git", "apply", "quarkus_3.x.patch"), appDir);
             }
 
@@ -372,7 +372,7 @@ public class PerfCheckTest {
                     "quarkus-json-native-image-source-jar", "quarkus-json.json").toFile());
             Logs.archiveLog(cn, mn, processLog);
             cleanTarget(app);
-            if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.0.0")) >= 0) {
+            if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_0_0) >= 0) {
                 runCommand(getRunCommand("git", "apply", "-R", "quarkus_3.x.patch"), appDir);
             }
         }
@@ -390,9 +390,9 @@ public class PerfCheckTest {
         final String mn = testInfo.getTestMethod().get().getName();
         final List<Map<String, String>> reports = new ArrayList<>(2);
         final String patch;
-        if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.7.0")) >= 0) {
+        if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_7_0) >= 0) {
             patch = "quarkus_3.7.x.patch";
-        } else if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.6.0")) >= 0) {
+        } else if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_6_0) >= 0) {
             patch = "quarkus_3.6.x.patch";
         } else if (QUARKUS_VERSION.majorIs(3)) {
             patch = "quarkus_3.x.patch";

--- a/testsuite/src/it/java/org/graalvm/tests/integration/RuntimesSmokeTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/RuntimesSmokeTest.java
@@ -188,9 +188,9 @@ public class RuntimesSmokeTest {
         }
 
         final String patch;
-        if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.7.0")) >= 0) {
+        if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_7_0) >= 0) {
             patch = "quarkus_3.7.x.patch";
-        } else if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.6.0")) >= 0) {
+        } else if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_6_0) >= 0) {
             patch = "quarkus_3.6.x.patch";
         } else if (QUARKUS_VERSION.majorIs(3)) {
             patch = "quarkus_3.x.patch";
@@ -215,7 +215,7 @@ public class RuntimesSmokeTest {
     @Tag("quarkus")
     public void quarkusEncodingIssues(TestInfo testInfo) throws IOException, InterruptedException {
         Apps apps = Apps.QUARKUS_BUILDER_IMAGE_ENCODING;
-        if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.0.0")) >= 0) {
+        if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_0_0) >= 0) {
             try {
                 runCommand(getRunCommand("git", "apply", "quarkus_3.x.patch"),
                         Path.of(BASE_DIR, apps.dir).toFile());

--- a/testsuite/src/it/java/org/graalvm/tests/integration/RuntimesSmokeTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/RuntimesSmokeTest.java
@@ -188,7 +188,7 @@ public class RuntimesSmokeTest {
         }
 
         final String patch;
-        if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.7.0")) >= 0 || QUARKUS_VERSION.isSnapshot()) {
+        if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.7.0")) >= 0) {
             patch = "quarkus_3.7.x.patch";
         } else if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.6.0")) >= 0) {
             patch = "quarkus_3.6.x.patch";
@@ -215,7 +215,7 @@ public class RuntimesSmokeTest {
     @Tag("quarkus")
     public void quarkusEncodingIssues(TestInfo testInfo) throws IOException, InterruptedException {
         Apps apps = Apps.QUARKUS_BUILDER_IMAGE_ENCODING;
-        if (QUARKUS_VERSION.majorIs(3) || QUARKUS_VERSION.isSnapshot()) {
+        if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.0.0")) >= 0) {
             try {
                 runCommand(getRunCommand("git", "apply", "quarkus_3.x.patch"),
                         Path.of(BASE_DIR, apps.dir).toFile());

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/QuarkusVersion.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/QuarkusVersion.java
@@ -23,6 +23,13 @@ import static org.graalvm.tests.integration.utils.Commands.getProperty;
 
 public class QuarkusVersion implements Comparable<QuarkusVersion> {
 
+
+    public static final QuarkusVersion V_2_2_4 = new QuarkusVersion("2.2.4");
+    public static final QuarkusVersion V_2_3_0 = new QuarkusVersion("2.3.0");
+    public static final QuarkusVersion V_2_4_0 = new QuarkusVersion("2.4.0");
+    public static final QuarkusVersion V_3_0_0 = new QuarkusVersion("3.0.0");
+    public static final QuarkusVersion V_3_6_0 = new QuarkusVersion("3.6.0");
+    public static final QuarkusVersion V_3_7_0 = new QuarkusVersion("3.7.0");
     private final String version;
     private final int major;
     private final int minor;

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/QuarkusVersion.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/QuarkusVersion.java
@@ -40,32 +40,16 @@ public class QuarkusVersion implements Comparable<QuarkusVersion> {
     public QuarkusVersion(String version) {
         this.version = version;
         this.snapshot = version.contains("SNAPSHOT");
-        if (this.snapshot) {
-            this.major = Integer.parseInt(version.split("-")[0]);
-            this.minor = 0;
-            this.patch = 0;
-            this.gitSHA = getProperty("QUARKUS_VERSION_GITSHA", "");
-        } else {
-            final String[] split = version.split("\\.");
-            this.major = Integer.parseInt(split[0]);
-            this.minor = split.length > 1 ? Integer.parseInt(split[1]) : 0;
-            this.patch = split.length > 2 ? Integer.parseInt(split[2]) : 0;
-            this.gitSHA = null;
-        }
+        final String versionWithoutSnapshot = version.split("-")[0];
+        final String[] split = versionWithoutSnapshot.split("\\.");
+        this.major = Integer.parseInt(split[0]);
+        this.minor = split.length > 1 ? Integer.parseInt(split[1]) : 0;
+        this.patch = split.length > 2 ? Integer.parseInt(split[2]) : 0;
+        this.gitSHA = getProperty("QUARKUS_VERSION_GITSHA", "");
     }
 
     @Override
     public int compareTo(QuarkusVersion other) {
-        if (this.snapshot) {
-            if (other.snapshot) {
-                return 0;
-            } else {
-                return 1;
-            }
-        }
-        if (other.snapshot) {
-            return -1;
-        }
         int result = this.major - other.major;
         if (result != 0) {
             return result;
@@ -77,6 +61,16 @@ public class QuarkusVersion implements Comparable<QuarkusVersion> {
         result = this.patch - other.patch;
         if (result != 0) {
             return result;
+        }
+        if (this.snapshot) {
+            if (other.snapshot) {
+                return 0;
+            } else {
+                return 1;
+            }
+        }
+        if (other.snapshot) {
+            return -1;
         }
         return 0;
     }

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/QuarkusVersionTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/QuarkusVersionTest.java
@@ -1,0 +1,60 @@
+package org.graalvm.tests.integration.utils.versions;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Testing test suite...
+ *
+ * Test the QuarkusVersion class.
+ */
+@Tag("testing-testsuite")
+class QuarkusVersionTest
+{
+
+    @Test
+    void compareTo()
+    {
+        Assertions.assertEquals(0, QuarkusVersion.V_2_2_4.compareTo(new QuarkusVersion("2.2.4")));
+        Assertions.assertEquals(0, QuarkusVersion.V_2_2_4.compareTo(QuarkusVersion.V_2_2_4));
+        // comparison with different major
+        Assertions.assertTrue(QuarkusVersion.V_3_7_0.compareTo(QuarkusVersion.V_2_2_4) > 0);
+        Assertions.assertTrue(QuarkusVersion.V_2_4_0.compareTo(QuarkusVersion.V_3_0_0) < 0);
+        // comparison with different minor
+        Assertions.assertTrue(QuarkusVersion.V_2_3_0.compareTo(QuarkusVersion.V_2_2_4) > 0);
+        Assertions.assertTrue(QuarkusVersion.V_2_3_0.compareTo(QuarkusVersion.V_2_4_0) < 0);
+        // comparison with different patch
+        Assertions.assertTrue(QuarkusVersion.V_2_2_4.compareTo(new QuarkusVersion("2.2.3")) > 0);
+        Assertions.assertTrue(QuarkusVersion.V_2_2_4.compareTo(new QuarkusVersion("2.2.5")) < 0);
+        // comparison with snapshot
+        Assertions.assertTrue(new QuarkusVersion("2.2.4-SNAPSHOT").compareTo(QuarkusVersion.V_2_2_4) > 0);
+        Assertions.assertTrue(QuarkusVersion.V_2_2_4.compareTo(new QuarkusVersion("2.2.4-SNAPSHOT")) < 0);
+        Assertions.assertTrue(new QuarkusVersion("2.3.4-SNAPSHOT").compareTo(new QuarkusVersion("2.2.4-SNAPSHOT")) > 0);
+        Assertions.assertTrue(new QuarkusVersion("2.3.4-SNAPSHOT").compareTo(new QuarkusVersion("3.2.4-SNAPSHOT")) < 0);
+    }
+
+    @Test
+    void majorIs()
+    {
+        Assertions.assertTrue(QuarkusVersion.V_2_2_4.majorIs(2));
+        Assertions.assertTrue(new QuarkusVersion("1.3.4-SNAPSHOT").majorIs(1));
+        Assertions.assertTrue(QuarkusVersion.V_3_7_0.majorIs(3));
+        Assertions.assertTrue(new QuarkusVersion("3.2.1-SNAPSHOT").majorIs(3));
+        Assertions.assertFalse(QuarkusVersion.V_3_7_0.majorIs(2));
+        Assertions.assertFalse(new QuarkusVersion("3.2.1-SNAPSHOT").majorIs(5));
+    }
+
+    @Test
+    void isSnapshot()
+    {
+        Assertions.assertFalse(QuarkusVersion.V_2_2_4.isSnapshot());
+        Assertions.assertTrue(new QuarkusVersion("1.3.4-SNAPSHOT").isSnapshot());
+        Assertions.assertFalse(new QuarkusVersion("1.3.4.Final").isSnapshot());
+        Assertions.assertFalse(QuarkusVersion.V_3_7_0.isSnapshot());
+        Assertions.assertTrue(new QuarkusVersion("3.2.1-SNAPSHOT").isSnapshot());
+        Assertions.assertFalse(new QuarkusVersion("3.2.1-ABD").isSnapshot());
+    }
+}


### PR DESCRIPTION
See
https://github.com/quarkusio/quarkus/blob/3c8c772dda9ed99674c9d8a6cd9cb4635d1ce5a2/build-parent/pom.xml#L8
and
https://github.com/quarkusio/quarkus/blob/bc0ca288d32ba2df212d8c4a2783c0bb21ca99a1/build-parent/pom.xml#L8

Relates to https://github.com/graalvm/mandrel/issues/501
