### PR TITLE
Remove quarkus.otel.traces.eusp.enabled=true from quarkus_3.7.x.patch

### DIFF
--- a/apps/quarkus-full-microprofile/quarkus_3.7.x.patch
+++ b/apps/quarkus-full-microprofile/quarkus_3.7.x.patch
@@ -232,10 +232,10 @@ index fb82305..a95c3f0 100644
  import java.io.IOException;
  import java.io.InputStreamReader;
 diff --git a/apps/quarkus-full-microprofile/src/main/resources/application.properties b/apps/quarkus-full-microprofile/src/main/resources/application.properties
-index 30c3d85..aacd280 100644
+index 30c3d85..ea679ae 100644
 --- a/apps/quarkus-full-microprofile/src/main/resources/application.properties
 +++ b/apps/quarkus-full-microprofile/src/main/resources/application.properties
-@@ -5,8 +5,10 @@ quarkus.ssl.native=true
+@@ -5,8 +5,9 @@ quarkus.ssl.native=true
  mp.jwt.verify.publickey.location=META-INF/resources/publicKey.pem
  mp.jwt.verify.issuer=https://server.example.com
  quarkus.smallrye-jwt.enabled=true
@@ -245,7 +245,6 @@ index 30c3d85..aacd280 100644
 -quarkus.jaeger.endpoint=http://localhost:14268/api/traces
 +quarkus.otel.traces.exporter=cdi
 +quarkus.otel.traces.sampler=parentbased_always_on
-+quarkus.otel.traces.eusp.enabled=true
 +quarkus.otel.service.name=Demo-Service-A
 +quarkus.otel.exporter.otlp.endpoint=http://localhost:4317
 +quarkus.otel.exporter.otlp.traces.endpoint=http://localhost:4317


### PR DESCRIPTION
This doesn't seem to be needed for the tests to work.

Closes: #252