### PR TITLE
Allow list old Mandrel version warning for JFR perf tests

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
@@ -290,6 +290,8 @@ public enum WhitelistLogLines {
                         // and https://github.com/oracle/graal/commit/5fc14c42fd8bbad0c8e661b4ebd8f96255f86e6b
                         Pattern.compile(".*Warning: Option 'DynamicProxyConfigurationResources' is deprecated and might be removed in a future release\\. Please refer to the GraalVM release notes.*"),
                         Pattern.compile(".*Warning: Option 'DynamicProxyConfigurationResources' is deprecated and might be removed in a future release: This can be caused by a proxy-config.json file in your META-INF directory.*"),
+                        // Allow the quarkus main warning of older Mandrel releases
+                        Pattern.compile(".*\\[WARNING\\] \\[io.quarkus.deployment.pkg.steps.NativeImageBuildStep\\] You are using an older version of GraalVM or Mandrel : 23\\.0.* Quarkus currently supports 23.1.* Please upgrade to this version\\..*"),
                 };
             }
         }


### PR DESCRIPTION
The fix from #265 was incomplete. The JFR perf tests use the JFR config for allow-listed log lines.

The `JFRTest.jfrPerfTest` uses this code:

```
    public void jfrPerfTestRun(TestInfo testInfo, boolean inContainer) throws IOException, InterruptedException {
        final Apps appJfr = inContainer ? Apps.JFR_PERFORMANCE_BUILDER_IMAGE : Apps.JFR_PERFORMANCE;
        final Apps appNoJfr = inContainer ? Apps.PLAINTEXT_PERFORMANCE_BUILDER_IMAGE : Apps.PLAINTEXT_PERFORMANCE;
```

... and both `Apps.JFR_PERFORMANCE` and `Apps.PLAINTEXT_PERFORMANCE` use `WhitelistLogLines.JFR` config which this patch is fixing.