### PR TITLE
Monitor field offset test

### DIFF
--- a/apps/jfr-native-image-performance/src/main/docker/Dockerfile.native
+++ b/apps/jfr-native-image-performance/src/main/docker/Dockerfile.native
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10
 WORKDIR /work/
 COPY target/*-runner /work/application
 COPY jfr-perf.jfc /work/jfr-perf.jfc

--- a/apps/monitor-field-offset/Dockerfile
+++ b/apps/monitor-field-offset/Dockerfile
@@ -1,5 +1,4 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10
-RUN microdnf install freetype fontconfig
 WORKDIR /work/
 RUN chown 100 /work \
     && chmod "g+rwX" /work \

--- a/apps/monitor-field-offset/pom.xml
+++ b/apps/monitor-field-offset/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>monitor-field-offset</groupId>
+    <artifactId>monitor-field-offsets</artifactId>
+    <version>1</version>
+
+    <name>monitor-field-offsets</name>
+
+    <parent>
+        <groupId>org.graalvm.tests.integration</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <properties>
+        <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.version}</version>
+                <configuration>
+                    <compilerArgs>
+                        <arg>--add-exports</arg>
+                        <arg>java.base/jdk.internal.vm.annotation=ALL-UNNAMED</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <profiles>
+        <profile>
+            <id>OK</id>
+            <build>
+                <finalName>monitor-field-offsets-ok</finalName>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <version>${maven-jar-plugin.version}</version>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <mainClass>monitor_field_offset.Main479</mainClass>
+                                </manifest>
+                            </archive>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>NOK</id>
+            <build>
+                <finalName>monitor-field-offsets-nok</finalName>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <version>${maven-jar-plugin.version}</version>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <mainClass>monitor_field_offset.Main480</mainClass>
+                                </manifest>
+                            </archive>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/apps/monitor-field-offset/src/main/java/monitor_field_offset/Main479.java
+++ b/apps/monitor-field-offset/src/main/java/monitor_field_offset/Main479.java
@@ -1,0 +1,996 @@
+/*
+ * Copyright (c) 2024, Red Hat Inc. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package monitor_field_offset;
+
+import jdk.internal.vm.annotation.Contended;
+
+/**
+ * @author Michal Karm Babacek <karm@redhat.com>
+ */
+public class Main479 {
+    @Contended
+    Integer int0 = 0;
+    @Contended
+    Integer int1 = 1;
+    @Contended
+    Integer int2 = 2;
+    @Contended
+    Integer int3 = 3;
+    @Contended
+    Integer int4 = 4;
+    @Contended
+    Integer int5 = 5;
+    @Contended
+    Integer int6 = 6;
+    @Contended
+    Integer int7 = 7;
+    @Contended
+    Integer int8 = 8;
+    @Contended
+    Integer int9 = 9;
+    @Contended
+    Integer int10 = 10;
+    @Contended
+    Integer int11 = 11;
+    @Contended
+    Integer int12 = 12;
+    @Contended
+    Integer int13 = 13;
+    @Contended
+    Integer int14 = 14;
+    @Contended
+    Integer int15 = 15;
+    @Contended
+    Integer int16 = 16;
+    @Contended
+    Integer int17 = 17;
+    @Contended
+    Integer int18 = 18;
+    @Contended
+    Integer int19 = 19;
+    @Contended
+    Integer int20 = 20;
+    @Contended
+    Integer int21 = 21;
+    @Contended
+    Integer int22 = 22;
+    @Contended
+    Integer int23 = 23;
+    @Contended
+    Integer int24 = 24;
+    @Contended
+    Integer int25 = 25;
+    @Contended
+    Integer int26 = 26;
+    @Contended
+    Integer int27 = 27;
+    @Contended
+    Integer int28 = 28;
+    @Contended
+    Integer int29 = 29;
+    @Contended
+    Integer int30 = 30;
+    @Contended
+    Integer int31 = 31;
+    @Contended
+    Integer int32 = 32;
+    @Contended
+    Integer int33 = 33;
+    @Contended
+    Integer int34 = 34;
+    @Contended
+    Integer int35 = 35;
+    @Contended
+    Integer int36 = 36;
+    @Contended
+    Integer int37 = 37;
+    @Contended
+    Integer int38 = 38;
+    @Contended
+    Integer int39 = 39;
+    @Contended
+    Integer int40 = 40;
+    @Contended
+    Integer int41 = 41;
+    @Contended
+    Integer int42 = 42;
+    @Contended
+    Integer int43 = 43;
+    @Contended
+    Integer int44 = 44;
+    @Contended
+    Integer int45 = 45;
+    @Contended
+    Integer int46 = 46;
+    @Contended
+    Integer int47 = 47;
+    @Contended
+    Integer int48 = 48;
+    @Contended
+    Integer int49 = 49;
+    @Contended
+    Integer int50 = 50;
+    @Contended
+    Integer int51 = 51;
+    @Contended
+    Integer int52 = 52;
+    @Contended
+    Integer int53 = 53;
+    @Contended
+    Integer int54 = 54;
+    @Contended
+    Integer int55 = 55;
+    @Contended
+    Integer int56 = 56;
+    @Contended
+    Integer int57 = 57;
+    @Contended
+    Integer int58 = 58;
+    @Contended
+    Integer int59 = 59;
+    @Contended
+    Integer int60 = 60;
+    @Contended
+    Integer int61 = 61;
+    @Contended
+    Integer int62 = 62;
+    @Contended
+    Integer int63 = 63;
+    @Contended
+    Integer int64 = 64;
+    @Contended
+    Integer int65 = 65;
+    @Contended
+    Integer int66 = 66;
+    @Contended
+    Integer int67 = 67;
+    @Contended
+    Integer int68 = 68;
+    @Contended
+    Integer int69 = 69;
+    @Contended
+    Integer int70 = 70;
+    @Contended
+    Integer int71 = 71;
+    @Contended
+    Integer int72 = 72;
+    @Contended
+    Integer int73 = 73;
+    @Contended
+    Integer int74 = 74;
+    @Contended
+    Integer int75 = 75;
+    @Contended
+    Integer int76 = 76;
+    @Contended
+    Integer int77 = 77;
+    @Contended
+    Integer int78 = 78;
+    @Contended
+    Integer int79 = 79;
+    @Contended
+    Integer int80 = 80;
+    @Contended
+    Integer int81 = 81;
+    @Contended
+    Integer int82 = 82;
+    @Contended
+    Integer int83 = 83;
+    @Contended
+    Integer int84 = 84;
+    @Contended
+    Integer int85 = 85;
+    @Contended
+    Integer int86 = 86;
+    @Contended
+    Integer int87 = 87;
+    @Contended
+    Integer int88 = 88;
+    @Contended
+    Integer int89 = 89;
+    @Contended
+    Integer int90 = 90;
+    @Contended
+    Integer int91 = 91;
+    @Contended
+    Integer int92 = 92;
+    @Contended
+    Integer int93 = 93;
+    @Contended
+    Integer int94 = 94;
+    @Contended
+    Integer int95 = 95;
+    @Contended
+    Integer int96 = 96;
+    @Contended
+    Integer int97 = 97;
+    @Contended
+    Integer int98 = 98;
+    @Contended
+    Integer int99 = 99;
+    @Contended
+    Integer int100 = 100;
+    @Contended
+    Integer int101 = 101;
+    @Contended
+    Integer int102 = 102;
+    @Contended
+    Integer int103 = 103;
+    @Contended
+    Integer int104 = 104;
+    @Contended
+    Integer int105 = 105;
+    @Contended
+    Integer int106 = 106;
+    @Contended
+    Integer int107 = 107;
+    @Contended
+    Integer int108 = 108;
+    @Contended
+    Integer int109 = 109;
+    @Contended
+    Integer int110 = 110;
+    @Contended
+    Integer int111 = 111;
+    @Contended
+    Integer int112 = 112;
+    @Contended
+    Integer int113 = 113;
+    @Contended
+    Integer int114 = 114;
+    @Contended
+    Integer int115 = 115;
+    @Contended
+    Integer int116 = 116;
+    @Contended
+    Integer int117 = 117;
+    @Contended
+    Integer int118 = 118;
+    @Contended
+    Integer int119 = 119;
+    @Contended
+    Integer int120 = 120;
+    @Contended
+    Integer int121 = 121;
+    @Contended
+    Integer int122 = 122;
+    @Contended
+    Integer int123 = 123;
+    @Contended
+    Integer int124 = 124;
+    @Contended
+    Integer int125 = 125;
+    @Contended
+    Integer int126 = 126;
+    @Contended
+    Integer int127 = 127;
+    @Contended
+    Integer int128 = 128;
+    @Contended
+    Integer int129 = 129;
+    @Contended
+    Integer int130 = 130;
+    @Contended
+    Integer int131 = 131;
+    @Contended
+    Integer int132 = 132;
+    @Contended
+    Integer int133 = 133;
+    @Contended
+    Integer int134 = 134;
+    @Contended
+    Integer int135 = 135;
+    @Contended
+    Integer int136 = 136;
+    @Contended
+    Integer int137 = 137;
+    @Contended
+    Integer int138 = 138;
+    @Contended
+    Integer int139 = 139;
+    @Contended
+    Integer int140 = 140;
+    @Contended
+    Integer int141 = 141;
+    @Contended
+    Integer int142 = 142;
+    @Contended
+    Integer int143 = 143;
+    @Contended
+    Integer int144 = 144;
+    @Contended
+    Integer int145 = 145;
+    @Contended
+    Integer int146 = 146;
+    @Contended
+    Integer int147 = 147;
+    @Contended
+    Integer int148 = 148;
+    @Contended
+    Integer int149 = 149;
+    @Contended
+    Integer int150 = 150;
+    @Contended
+    Integer int151 = 151;
+    @Contended
+    Integer int152 = 152;
+    @Contended
+    Integer int153 = 153;
+    @Contended
+    Integer int154 = 154;
+    @Contended
+    Integer int155 = 155;
+    @Contended
+    Integer int156 = 156;
+    @Contended
+    Integer int157 = 157;
+    @Contended
+    Integer int158 = 158;
+    @Contended
+    Integer int159 = 159;
+    @Contended
+    Integer int160 = 160;
+    @Contended
+    Integer int161 = 161;
+    @Contended
+    Integer int162 = 162;
+    @Contended
+    Integer int163 = 163;
+    @Contended
+    Integer int164 = 164;
+    @Contended
+    Integer int165 = 165;
+    @Contended
+    Integer int166 = 166;
+    @Contended
+    Integer int167 = 167;
+    @Contended
+    Integer int168 = 168;
+    @Contended
+    Integer int169 = 169;
+    @Contended
+    Integer int170 = 170;
+    @Contended
+    Integer int171 = 171;
+    @Contended
+    Integer int172 = 172;
+    @Contended
+    Integer int173 = 173;
+    @Contended
+    Integer int174 = 174;
+    @Contended
+    Integer int175 = 175;
+    @Contended
+    Integer int176 = 176;
+    @Contended
+    Integer int177 = 177;
+    @Contended
+    Integer int178 = 178;
+    @Contended
+    Integer int179 = 179;
+    @Contended
+    Integer int180 = 180;
+    @Contended
+    Integer int181 = 181;
+    @Contended
+    Integer int182 = 182;
+    @Contended
+    Integer int183 = 183;
+    @Contended
+    Integer int184 = 184;
+    @Contended
+    Integer int185 = 185;
+    @Contended
+    Integer int186 = 186;
+    @Contended
+    Integer int187 = 187;
+    @Contended
+    Integer int188 = 188;
+    @Contended
+    Integer int189 = 189;
+    @Contended
+    Integer int190 = 190;
+    @Contended
+    Integer int191 = 191;
+    @Contended
+    Integer int192 = 192;
+    @Contended
+    Integer int193 = 193;
+    @Contended
+    Integer int194 = 194;
+    @Contended
+    Integer int195 = 195;
+    @Contended
+    Integer int196 = 196;
+    @Contended
+    Integer int197 = 197;
+    @Contended
+    Integer int198 = 198;
+    @Contended
+    Integer int199 = 199;
+    @Contended
+    Integer int200 = 200;
+    @Contended
+    Integer int201 = 201;
+    @Contended
+    Integer int202 = 202;
+    @Contended
+    Integer int203 = 203;
+    @Contended
+    Integer int204 = 204;
+    @Contended
+    Integer int205 = 205;
+    @Contended
+    Integer int206 = 206;
+    @Contended
+    Integer int207 = 207;
+    @Contended
+    Integer int208 = 208;
+    @Contended
+    Integer int209 = 209;
+    @Contended
+    Integer int210 = 210;
+    @Contended
+    Integer int211 = 211;
+    @Contended
+    Integer int212 = 212;
+    @Contended
+    Integer int213 = 213;
+    @Contended
+    Integer int214 = 214;
+    @Contended
+    Integer int215 = 215;
+    @Contended
+    Integer int216 = 216;
+    @Contended
+    Integer int217 = 217;
+    @Contended
+    Integer int218 = 218;
+    @Contended
+    Integer int219 = 219;
+    @Contended
+    Integer int220 = 220;
+    @Contended
+    Integer int221 = 221;
+    @Contended
+    Integer int222 = 222;
+    @Contended
+    Integer int223 = 223;
+    @Contended
+    Integer int224 = 224;
+    @Contended
+    Integer int225 = 225;
+    @Contended
+    Integer int226 = 226;
+    @Contended
+    Integer int227 = 227;
+    @Contended
+    Integer int228 = 228;
+    @Contended
+    Integer int229 = 229;
+    @Contended
+    Integer int230 = 230;
+    @Contended
+    Integer int231 = 231;
+    @Contended
+    Integer int232 = 232;
+    @Contended
+    Integer int233 = 233;
+    @Contended
+    Integer int234 = 234;
+    @Contended
+    Integer int235 = 235;
+    @Contended
+    Integer int236 = 236;
+    @Contended
+    Integer int237 = 237;
+    @Contended
+    Integer int238 = 238;
+    @Contended
+    Integer int239 = 239;
+    @Contended
+    Integer int240 = 240;
+    @Contended
+    Integer int241 = 241;
+    @Contended
+    Integer int242 = 242;
+    @Contended
+    Integer int243 = 243;
+    @Contended
+    Integer int244 = 244;
+    @Contended
+    Integer int245 = 245;
+    @Contended
+    Integer int246 = 246;
+    @Contended
+    Integer int247 = 247;
+    @Contended
+    Integer int248 = 248;
+    @Contended
+    Integer int249 = 249;
+    @Contended
+    Integer int250 = 250;
+    @Contended
+    Integer int251 = 251;
+    @Contended
+    Integer int252 = 252;
+    @Contended
+    Integer int253 = 253;
+    @Contended
+    Integer int254 = 254;
+    @Contended
+    Integer int255 = 255;
+    @Contended
+    Integer int256 = 256;
+    @Contended
+    Integer int257 = 257;
+    @Contended
+    Integer int258 = 258;
+    @Contended
+    Integer int259 = 259;
+    @Contended
+    Integer int260 = 260;
+    @Contended
+    Integer int261 = 261;
+    @Contended
+    Integer int262 = 262;
+    @Contended
+    Integer int263 = 263;
+    @Contended
+    Integer int264 = 264;
+    @Contended
+    Integer int265 = 265;
+    @Contended
+    Integer int266 = 266;
+    @Contended
+    Integer int267 = 267;
+    @Contended
+    Integer int268 = 268;
+    @Contended
+    Integer int269 = 269;
+    @Contended
+    Integer int270 = 270;
+    @Contended
+    Integer int271 = 271;
+    @Contended
+    Integer int272 = 272;
+    @Contended
+    Integer int273 = 273;
+    @Contended
+    Integer int274 = 274;
+    @Contended
+    Integer int275 = 275;
+    @Contended
+    Integer int276 = 276;
+    @Contended
+    Integer int277 = 277;
+    @Contended
+    Integer int278 = 278;
+    @Contended
+    Integer int279 = 279;
+    @Contended
+    Integer int280 = 280;
+    @Contended
+    Integer int281 = 281;
+    @Contended
+    Integer int282 = 282;
+    @Contended
+    Integer int283 = 283;
+    @Contended
+    Integer int284 = 284;
+    @Contended
+    Integer int285 = 285;
+    @Contended
+    Integer int286 = 286;
+    @Contended
+    Integer int287 = 287;
+    @Contended
+    Integer int288 = 288;
+    @Contended
+    Integer int289 = 289;
+    @Contended
+    Integer int290 = 290;
+    @Contended
+    Integer int291 = 291;
+    @Contended
+    Integer int292 = 292;
+    @Contended
+    Integer int293 = 293;
+    @Contended
+    Integer int294 = 294;
+    @Contended
+    Integer int295 = 295;
+    @Contended
+    Integer int296 = 296;
+    @Contended
+    Integer int297 = 297;
+    @Contended
+    Integer int298 = 298;
+    @Contended
+    Integer int299 = 299;
+    @Contended
+    Integer int300 = 300;
+    @Contended
+    Integer int301 = 301;
+    @Contended
+    Integer int302 = 302;
+    @Contended
+    Integer int303 = 303;
+    @Contended
+    Integer int304 = 304;
+    @Contended
+    Integer int305 = 305;
+    @Contended
+    Integer int306 = 306;
+    @Contended
+    Integer int307 = 307;
+    @Contended
+    Integer int308 = 308;
+    @Contended
+    Integer int309 = 309;
+    @Contended
+    Integer int310 = 310;
+    @Contended
+    Integer int311 = 311;
+    @Contended
+    Integer int312 = 312;
+    @Contended
+    Integer int313 = 313;
+    @Contended
+    Integer int314 = 314;
+    @Contended
+    Integer int315 = 315;
+    @Contended
+    Integer int316 = 316;
+    @Contended
+    Integer int317 = 317;
+    @Contended
+    Integer int318 = 318;
+    @Contended
+    Integer int319 = 319;
+    @Contended
+    Integer int320 = 320;
+    @Contended
+    Integer int321 = 321;
+    @Contended
+    Integer int322 = 322;
+    @Contended
+    Integer int323 = 323;
+    @Contended
+    Integer int324 = 324;
+    @Contended
+    Integer int325 = 325;
+    @Contended
+    Integer int326 = 326;
+    @Contended
+    Integer int327 = 327;
+    @Contended
+    Integer int328 = 328;
+    @Contended
+    Integer int329 = 329;
+    @Contended
+    Integer int330 = 330;
+    @Contended
+    Integer int331 = 331;
+    @Contended
+    Integer int332 = 332;
+    @Contended
+    Integer int333 = 333;
+    @Contended
+    Integer int334 = 334;
+    @Contended
+    Integer int335 = 335;
+    @Contended
+    Integer int336 = 336;
+    @Contended
+    Integer int337 = 337;
+    @Contended
+    Integer int338 = 338;
+    @Contended
+    Integer int339 = 339;
+    @Contended
+    Integer int340 = 340;
+    @Contended
+    Integer int341 = 341;
+    @Contended
+    Integer int342 = 342;
+    @Contended
+    Integer int343 = 343;
+    @Contended
+    Integer int344 = 344;
+    @Contended
+    Integer int345 = 345;
+    @Contended
+    Integer int346 = 346;
+    @Contended
+    Integer int347 = 347;
+    @Contended
+    Integer int348 = 348;
+    @Contended
+    Integer int349 = 349;
+    @Contended
+    Integer int350 = 350;
+    @Contended
+    Integer int351 = 351;
+    @Contended
+    Integer int352 = 352;
+    @Contended
+    Integer int353 = 353;
+    @Contended
+    Integer int354 = 354;
+    @Contended
+    Integer int355 = 355;
+    @Contended
+    Integer int356 = 356;
+    @Contended
+    Integer int357 = 357;
+    @Contended
+    Integer int358 = 358;
+    @Contended
+    Integer int359 = 359;
+    @Contended
+    Integer int360 = 360;
+    @Contended
+    Integer int361 = 361;
+    @Contended
+    Integer int362 = 362;
+    @Contended
+    Integer int363 = 363;
+    @Contended
+    Integer int364 = 364;
+    @Contended
+    Integer int365 = 365;
+    @Contended
+    Integer int366 = 366;
+    @Contended
+    Integer int367 = 367;
+    @Contended
+    Integer int368 = 368;
+    @Contended
+    Integer int369 = 369;
+    @Contended
+    Integer int370 = 370;
+    @Contended
+    Integer int371 = 371;
+    @Contended
+    Integer int372 = 372;
+    @Contended
+    Integer int373 = 373;
+    @Contended
+    Integer int374 = 374;
+    @Contended
+    Integer int375 = 375;
+    @Contended
+    Integer int376 = 376;
+    @Contended
+    Integer int377 = 377;
+    @Contended
+    Integer int378 = 378;
+    @Contended
+    Integer int379 = 379;
+    @Contended
+    Integer int380 = 380;
+    @Contended
+    Integer int381 = 381;
+    @Contended
+    Integer int382 = 382;
+    @Contended
+    Integer int383 = 383;
+    @Contended
+    Integer int384 = 384;
+    @Contended
+    Integer int385 = 385;
+    @Contended
+    Integer int386 = 386;
+    @Contended
+    Integer int387 = 387;
+    @Contended
+    Integer int388 = 388;
+    @Contended
+    Integer int389 = 389;
+    @Contended
+    Integer int390 = 390;
+    @Contended
+    Integer int391 = 391;
+    @Contended
+    Integer int392 = 392;
+    @Contended
+    Integer int393 = 393;
+    @Contended
+    Integer int394 = 394;
+    @Contended
+    Integer int395 = 395;
+    @Contended
+    Integer int396 = 396;
+    @Contended
+    Integer int397 = 397;
+    @Contended
+    Integer int398 = 398;
+    @Contended
+    Integer int399 = 399;
+    @Contended
+    Integer int400 = 400;
+    @Contended
+    Integer int401 = 401;
+    @Contended
+    Integer int402 = 402;
+    @Contended
+    Integer int403 = 403;
+    @Contended
+    Integer int404 = 404;
+    @Contended
+    Integer int405 = 405;
+    @Contended
+    Integer int406 = 406;
+    @Contended
+    Integer int407 = 407;
+    @Contended
+    Integer int408 = 408;
+    @Contended
+    Integer int409 = 409;
+    @Contended
+    Integer int410 = 410;
+    @Contended
+    Integer int411 = 411;
+    @Contended
+    Integer int412 = 412;
+    @Contended
+    Integer int413 = 413;
+    @Contended
+    Integer int414 = 414;
+    @Contended
+    Integer int415 = 415;
+    @Contended
+    Integer int416 = 416;
+    @Contended
+    Integer int417 = 417;
+    @Contended
+    Integer int418 = 418;
+    @Contended
+    Integer int419 = 419;
+    @Contended
+    Integer int420 = 420;
+    @Contended
+    Integer int421 = 421;
+    @Contended
+    Integer int422 = 422;
+    @Contended
+    Integer int423 = 423;
+    @Contended
+    Integer int424 = 424;
+    @Contended
+    Integer int425 = 425;
+    @Contended
+    Integer int426 = 426;
+    @Contended
+    Integer int427 = 427;
+    @Contended
+    Integer int428 = 428;
+    @Contended
+    Integer int429 = 429;
+    @Contended
+    Integer int430 = 430;
+    @Contended
+    Integer int431 = 431;
+    @Contended
+    Integer int432 = 432;
+    @Contended
+    Integer int433 = 433;
+    @Contended
+    Integer int434 = 434;
+    @Contended
+    Integer int435 = 435;
+    @Contended
+    Integer int436 = 436;
+    @Contended
+    Integer int437 = 437;
+    @Contended
+    Integer int438 = 438;
+    @Contended
+    Integer int439 = 439;
+    @Contended
+    Integer int440 = 440;
+    @Contended
+    Integer int441 = 441;
+    @Contended
+    Integer int442 = 442;
+    @Contended
+    Integer int443 = 443;
+    @Contended
+    Integer int444 = 444;
+    @Contended
+    Integer int445 = 445;
+    @Contended
+    Integer int446 = 446;
+    @Contended
+    Integer int447 = 447;
+    @Contended
+    Integer int448 = 448;
+    @Contended
+    Integer int449 = 449;
+    @Contended
+    Integer int450 = 450;
+    @Contended
+    Integer int451 = 451;
+    @Contended
+    Integer int452 = 452;
+    @Contended
+    Integer int453 = 453;
+    @Contended
+    Integer int454 = 454;
+    @Contended
+    Integer int455 = 455;
+    @Contended
+    Integer int456 = 456;
+    @Contended
+    Integer int457 = 457;
+    @Contended
+    Integer int458 = 458;
+    @Contended
+    Integer int459 = 459;
+    @Contended
+    Integer int460 = 460;
+    @Contended
+    Integer int461 = 461;
+    @Contended
+    Integer int462 = 462;
+    @Contended
+    Integer int463 = 463;
+    @Contended
+    Integer int464 = 464;
+    @Contended
+    Integer int465 = 465;
+    @Contended
+    Integer int466 = 466;
+    @Contended
+    Integer int467 = 467;
+    @Contended
+    Integer int468 = 468;
+    @Contended
+    Integer int469 = 469;
+    @Contended
+    Integer int470 = 470;
+    @Contended
+    Integer int471 = 471;
+    @Contended
+    Integer int472 = 472;
+    @Contended
+    Integer int473 = 473;
+    @Contended
+    Integer int474 = 474;
+    @Contended
+    Integer int475 = 475;
+    @Contended
+    Integer int476 = 476;
+    @Contended
+    Integer int477 = 477;
+    @Contended
+    Integer int478 = 478;
+    @Contended
+    Integer int479 = 479;
+    static volatile Main479 instance;
+    public static void main(String[] args) {
+        int c = 0;
+        for (; c < 9000; c++) {
+            instance = new Main479();
+        }
+        System.out.println("Done all " + c + " iterations.");
+    }
+}

--- a/apps/monitor-field-offset/src/main/java/monitor_field_offset/Main480.java
+++ b/apps/monitor-field-offset/src/main/java/monitor_field_offset/Main480.java
@@ -1,0 +1,998 @@
+/*
+ * Copyright (c) 2024, Red Hat Inc. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package monitor_field_offset;
+
+import jdk.internal.vm.annotation.Contended;
+
+/**
+ * @author Michal Karm Babacek <karm@redhat.com>
+ */
+public class Main480 {
+    @Contended
+    Integer int0 = 0;
+    @Contended
+    Integer int1 = 1;
+    @Contended
+    Integer int2 = 2;
+    @Contended
+    Integer int3 = 3;
+    @Contended
+    Integer int4 = 4;
+    @Contended
+    Integer int5 = 5;
+    @Contended
+    Integer int6 = 6;
+    @Contended
+    Integer int7 = 7;
+    @Contended
+    Integer int8 = 8;
+    @Contended
+    Integer int9 = 9;
+    @Contended
+    Integer int10 = 10;
+    @Contended
+    Integer int11 = 11;
+    @Contended
+    Integer int12 = 12;
+    @Contended
+    Integer int13 = 13;
+    @Contended
+    Integer int14 = 14;
+    @Contended
+    Integer int15 = 15;
+    @Contended
+    Integer int16 = 16;
+    @Contended
+    Integer int17 = 17;
+    @Contended
+    Integer int18 = 18;
+    @Contended
+    Integer int19 = 19;
+    @Contended
+    Integer int20 = 20;
+    @Contended
+    Integer int21 = 21;
+    @Contended
+    Integer int22 = 22;
+    @Contended
+    Integer int23 = 23;
+    @Contended
+    Integer int24 = 24;
+    @Contended
+    Integer int25 = 25;
+    @Contended
+    Integer int26 = 26;
+    @Contended
+    Integer int27 = 27;
+    @Contended
+    Integer int28 = 28;
+    @Contended
+    Integer int29 = 29;
+    @Contended
+    Integer int30 = 30;
+    @Contended
+    Integer int31 = 31;
+    @Contended
+    Integer int32 = 32;
+    @Contended
+    Integer int33 = 33;
+    @Contended
+    Integer int34 = 34;
+    @Contended
+    Integer int35 = 35;
+    @Contended
+    Integer int36 = 36;
+    @Contended
+    Integer int37 = 37;
+    @Contended
+    Integer int38 = 38;
+    @Contended
+    Integer int39 = 39;
+    @Contended
+    Integer int40 = 40;
+    @Contended
+    Integer int41 = 41;
+    @Contended
+    Integer int42 = 42;
+    @Contended
+    Integer int43 = 43;
+    @Contended
+    Integer int44 = 44;
+    @Contended
+    Integer int45 = 45;
+    @Contended
+    Integer int46 = 46;
+    @Contended
+    Integer int47 = 47;
+    @Contended
+    Integer int48 = 48;
+    @Contended
+    Integer int49 = 49;
+    @Contended
+    Integer int50 = 50;
+    @Contended
+    Integer int51 = 51;
+    @Contended
+    Integer int52 = 52;
+    @Contended
+    Integer int53 = 53;
+    @Contended
+    Integer int54 = 54;
+    @Contended
+    Integer int55 = 55;
+    @Contended
+    Integer int56 = 56;
+    @Contended
+    Integer int57 = 57;
+    @Contended
+    Integer int58 = 58;
+    @Contended
+    Integer int59 = 59;
+    @Contended
+    Integer int60 = 60;
+    @Contended
+    Integer int61 = 61;
+    @Contended
+    Integer int62 = 62;
+    @Contended
+    Integer int63 = 63;
+    @Contended
+    Integer int64 = 64;
+    @Contended
+    Integer int65 = 65;
+    @Contended
+    Integer int66 = 66;
+    @Contended
+    Integer int67 = 67;
+    @Contended
+    Integer int68 = 68;
+    @Contended
+    Integer int69 = 69;
+    @Contended
+    Integer int70 = 70;
+    @Contended
+    Integer int71 = 71;
+    @Contended
+    Integer int72 = 72;
+    @Contended
+    Integer int73 = 73;
+    @Contended
+    Integer int74 = 74;
+    @Contended
+    Integer int75 = 75;
+    @Contended
+    Integer int76 = 76;
+    @Contended
+    Integer int77 = 77;
+    @Contended
+    Integer int78 = 78;
+    @Contended
+    Integer int79 = 79;
+    @Contended
+    Integer int80 = 80;
+    @Contended
+    Integer int81 = 81;
+    @Contended
+    Integer int82 = 82;
+    @Contended
+    Integer int83 = 83;
+    @Contended
+    Integer int84 = 84;
+    @Contended
+    Integer int85 = 85;
+    @Contended
+    Integer int86 = 86;
+    @Contended
+    Integer int87 = 87;
+    @Contended
+    Integer int88 = 88;
+    @Contended
+    Integer int89 = 89;
+    @Contended
+    Integer int90 = 90;
+    @Contended
+    Integer int91 = 91;
+    @Contended
+    Integer int92 = 92;
+    @Contended
+    Integer int93 = 93;
+    @Contended
+    Integer int94 = 94;
+    @Contended
+    Integer int95 = 95;
+    @Contended
+    Integer int96 = 96;
+    @Contended
+    Integer int97 = 97;
+    @Contended
+    Integer int98 = 98;
+    @Contended
+    Integer int99 = 99;
+    @Contended
+    Integer int100 = 100;
+    @Contended
+    Integer int101 = 101;
+    @Contended
+    Integer int102 = 102;
+    @Contended
+    Integer int103 = 103;
+    @Contended
+    Integer int104 = 104;
+    @Contended
+    Integer int105 = 105;
+    @Contended
+    Integer int106 = 106;
+    @Contended
+    Integer int107 = 107;
+    @Contended
+    Integer int108 = 108;
+    @Contended
+    Integer int109 = 109;
+    @Contended
+    Integer int110 = 110;
+    @Contended
+    Integer int111 = 111;
+    @Contended
+    Integer int112 = 112;
+    @Contended
+    Integer int113 = 113;
+    @Contended
+    Integer int114 = 114;
+    @Contended
+    Integer int115 = 115;
+    @Contended
+    Integer int116 = 116;
+    @Contended
+    Integer int117 = 117;
+    @Contended
+    Integer int118 = 118;
+    @Contended
+    Integer int119 = 119;
+    @Contended
+    Integer int120 = 120;
+    @Contended
+    Integer int121 = 121;
+    @Contended
+    Integer int122 = 122;
+    @Contended
+    Integer int123 = 123;
+    @Contended
+    Integer int124 = 124;
+    @Contended
+    Integer int125 = 125;
+    @Contended
+    Integer int126 = 126;
+    @Contended
+    Integer int127 = 127;
+    @Contended
+    Integer int128 = 128;
+    @Contended
+    Integer int129 = 129;
+    @Contended
+    Integer int130 = 130;
+    @Contended
+    Integer int131 = 131;
+    @Contended
+    Integer int132 = 132;
+    @Contended
+    Integer int133 = 133;
+    @Contended
+    Integer int134 = 134;
+    @Contended
+    Integer int135 = 135;
+    @Contended
+    Integer int136 = 136;
+    @Contended
+    Integer int137 = 137;
+    @Contended
+    Integer int138 = 138;
+    @Contended
+    Integer int139 = 139;
+    @Contended
+    Integer int140 = 140;
+    @Contended
+    Integer int141 = 141;
+    @Contended
+    Integer int142 = 142;
+    @Contended
+    Integer int143 = 143;
+    @Contended
+    Integer int144 = 144;
+    @Contended
+    Integer int145 = 145;
+    @Contended
+    Integer int146 = 146;
+    @Contended
+    Integer int147 = 147;
+    @Contended
+    Integer int148 = 148;
+    @Contended
+    Integer int149 = 149;
+    @Contended
+    Integer int150 = 150;
+    @Contended
+    Integer int151 = 151;
+    @Contended
+    Integer int152 = 152;
+    @Contended
+    Integer int153 = 153;
+    @Contended
+    Integer int154 = 154;
+    @Contended
+    Integer int155 = 155;
+    @Contended
+    Integer int156 = 156;
+    @Contended
+    Integer int157 = 157;
+    @Contended
+    Integer int158 = 158;
+    @Contended
+    Integer int159 = 159;
+    @Contended
+    Integer int160 = 160;
+    @Contended
+    Integer int161 = 161;
+    @Contended
+    Integer int162 = 162;
+    @Contended
+    Integer int163 = 163;
+    @Contended
+    Integer int164 = 164;
+    @Contended
+    Integer int165 = 165;
+    @Contended
+    Integer int166 = 166;
+    @Contended
+    Integer int167 = 167;
+    @Contended
+    Integer int168 = 168;
+    @Contended
+    Integer int169 = 169;
+    @Contended
+    Integer int170 = 170;
+    @Contended
+    Integer int171 = 171;
+    @Contended
+    Integer int172 = 172;
+    @Contended
+    Integer int173 = 173;
+    @Contended
+    Integer int174 = 174;
+    @Contended
+    Integer int175 = 175;
+    @Contended
+    Integer int176 = 176;
+    @Contended
+    Integer int177 = 177;
+    @Contended
+    Integer int178 = 178;
+    @Contended
+    Integer int179 = 179;
+    @Contended
+    Integer int180 = 180;
+    @Contended
+    Integer int181 = 181;
+    @Contended
+    Integer int182 = 182;
+    @Contended
+    Integer int183 = 183;
+    @Contended
+    Integer int184 = 184;
+    @Contended
+    Integer int185 = 185;
+    @Contended
+    Integer int186 = 186;
+    @Contended
+    Integer int187 = 187;
+    @Contended
+    Integer int188 = 188;
+    @Contended
+    Integer int189 = 189;
+    @Contended
+    Integer int190 = 190;
+    @Contended
+    Integer int191 = 191;
+    @Contended
+    Integer int192 = 192;
+    @Contended
+    Integer int193 = 193;
+    @Contended
+    Integer int194 = 194;
+    @Contended
+    Integer int195 = 195;
+    @Contended
+    Integer int196 = 196;
+    @Contended
+    Integer int197 = 197;
+    @Contended
+    Integer int198 = 198;
+    @Contended
+    Integer int199 = 199;
+    @Contended
+    Integer int200 = 200;
+    @Contended
+    Integer int201 = 201;
+    @Contended
+    Integer int202 = 202;
+    @Contended
+    Integer int203 = 203;
+    @Contended
+    Integer int204 = 204;
+    @Contended
+    Integer int205 = 205;
+    @Contended
+    Integer int206 = 206;
+    @Contended
+    Integer int207 = 207;
+    @Contended
+    Integer int208 = 208;
+    @Contended
+    Integer int209 = 209;
+    @Contended
+    Integer int210 = 210;
+    @Contended
+    Integer int211 = 211;
+    @Contended
+    Integer int212 = 212;
+    @Contended
+    Integer int213 = 213;
+    @Contended
+    Integer int214 = 214;
+    @Contended
+    Integer int215 = 215;
+    @Contended
+    Integer int216 = 216;
+    @Contended
+    Integer int217 = 217;
+    @Contended
+    Integer int218 = 218;
+    @Contended
+    Integer int219 = 219;
+    @Contended
+    Integer int220 = 220;
+    @Contended
+    Integer int221 = 221;
+    @Contended
+    Integer int222 = 222;
+    @Contended
+    Integer int223 = 223;
+    @Contended
+    Integer int224 = 224;
+    @Contended
+    Integer int225 = 225;
+    @Contended
+    Integer int226 = 226;
+    @Contended
+    Integer int227 = 227;
+    @Contended
+    Integer int228 = 228;
+    @Contended
+    Integer int229 = 229;
+    @Contended
+    Integer int230 = 230;
+    @Contended
+    Integer int231 = 231;
+    @Contended
+    Integer int232 = 232;
+    @Contended
+    Integer int233 = 233;
+    @Contended
+    Integer int234 = 234;
+    @Contended
+    Integer int235 = 235;
+    @Contended
+    Integer int236 = 236;
+    @Contended
+    Integer int237 = 237;
+    @Contended
+    Integer int238 = 238;
+    @Contended
+    Integer int239 = 239;
+    @Contended
+    Integer int240 = 240;
+    @Contended
+    Integer int241 = 241;
+    @Contended
+    Integer int242 = 242;
+    @Contended
+    Integer int243 = 243;
+    @Contended
+    Integer int244 = 244;
+    @Contended
+    Integer int245 = 245;
+    @Contended
+    Integer int246 = 246;
+    @Contended
+    Integer int247 = 247;
+    @Contended
+    Integer int248 = 248;
+    @Contended
+    Integer int249 = 249;
+    @Contended
+    Integer int250 = 250;
+    @Contended
+    Integer int251 = 251;
+    @Contended
+    Integer int252 = 252;
+    @Contended
+    Integer int253 = 253;
+    @Contended
+    Integer int254 = 254;
+    @Contended
+    Integer int255 = 255;
+    @Contended
+    Integer int256 = 256;
+    @Contended
+    Integer int257 = 257;
+    @Contended
+    Integer int258 = 258;
+    @Contended
+    Integer int259 = 259;
+    @Contended
+    Integer int260 = 260;
+    @Contended
+    Integer int261 = 261;
+    @Contended
+    Integer int262 = 262;
+    @Contended
+    Integer int263 = 263;
+    @Contended
+    Integer int264 = 264;
+    @Contended
+    Integer int265 = 265;
+    @Contended
+    Integer int266 = 266;
+    @Contended
+    Integer int267 = 267;
+    @Contended
+    Integer int268 = 268;
+    @Contended
+    Integer int269 = 269;
+    @Contended
+    Integer int270 = 270;
+    @Contended
+    Integer int271 = 271;
+    @Contended
+    Integer int272 = 272;
+    @Contended
+    Integer int273 = 273;
+    @Contended
+    Integer int274 = 274;
+    @Contended
+    Integer int275 = 275;
+    @Contended
+    Integer int276 = 276;
+    @Contended
+    Integer int277 = 277;
+    @Contended
+    Integer int278 = 278;
+    @Contended
+    Integer int279 = 279;
+    @Contended
+    Integer int280 = 280;
+    @Contended
+    Integer int281 = 281;
+    @Contended
+    Integer int282 = 282;
+    @Contended
+    Integer int283 = 283;
+    @Contended
+    Integer int284 = 284;
+    @Contended
+    Integer int285 = 285;
+    @Contended
+    Integer int286 = 286;
+    @Contended
+    Integer int287 = 287;
+    @Contended
+    Integer int288 = 288;
+    @Contended
+    Integer int289 = 289;
+    @Contended
+    Integer int290 = 290;
+    @Contended
+    Integer int291 = 291;
+    @Contended
+    Integer int292 = 292;
+    @Contended
+    Integer int293 = 293;
+    @Contended
+    Integer int294 = 294;
+    @Contended
+    Integer int295 = 295;
+    @Contended
+    Integer int296 = 296;
+    @Contended
+    Integer int297 = 297;
+    @Contended
+    Integer int298 = 298;
+    @Contended
+    Integer int299 = 299;
+    @Contended
+    Integer int300 = 300;
+    @Contended
+    Integer int301 = 301;
+    @Contended
+    Integer int302 = 302;
+    @Contended
+    Integer int303 = 303;
+    @Contended
+    Integer int304 = 304;
+    @Contended
+    Integer int305 = 305;
+    @Contended
+    Integer int306 = 306;
+    @Contended
+    Integer int307 = 307;
+    @Contended
+    Integer int308 = 308;
+    @Contended
+    Integer int309 = 309;
+    @Contended
+    Integer int310 = 310;
+    @Contended
+    Integer int311 = 311;
+    @Contended
+    Integer int312 = 312;
+    @Contended
+    Integer int313 = 313;
+    @Contended
+    Integer int314 = 314;
+    @Contended
+    Integer int315 = 315;
+    @Contended
+    Integer int316 = 316;
+    @Contended
+    Integer int317 = 317;
+    @Contended
+    Integer int318 = 318;
+    @Contended
+    Integer int319 = 319;
+    @Contended
+    Integer int320 = 320;
+    @Contended
+    Integer int321 = 321;
+    @Contended
+    Integer int322 = 322;
+    @Contended
+    Integer int323 = 323;
+    @Contended
+    Integer int324 = 324;
+    @Contended
+    Integer int325 = 325;
+    @Contended
+    Integer int326 = 326;
+    @Contended
+    Integer int327 = 327;
+    @Contended
+    Integer int328 = 328;
+    @Contended
+    Integer int329 = 329;
+    @Contended
+    Integer int330 = 330;
+    @Contended
+    Integer int331 = 331;
+    @Contended
+    Integer int332 = 332;
+    @Contended
+    Integer int333 = 333;
+    @Contended
+    Integer int334 = 334;
+    @Contended
+    Integer int335 = 335;
+    @Contended
+    Integer int336 = 336;
+    @Contended
+    Integer int337 = 337;
+    @Contended
+    Integer int338 = 338;
+    @Contended
+    Integer int339 = 339;
+    @Contended
+    Integer int340 = 340;
+    @Contended
+    Integer int341 = 341;
+    @Contended
+    Integer int342 = 342;
+    @Contended
+    Integer int343 = 343;
+    @Contended
+    Integer int344 = 344;
+    @Contended
+    Integer int345 = 345;
+    @Contended
+    Integer int346 = 346;
+    @Contended
+    Integer int347 = 347;
+    @Contended
+    Integer int348 = 348;
+    @Contended
+    Integer int349 = 349;
+    @Contended
+    Integer int350 = 350;
+    @Contended
+    Integer int351 = 351;
+    @Contended
+    Integer int352 = 352;
+    @Contended
+    Integer int353 = 353;
+    @Contended
+    Integer int354 = 354;
+    @Contended
+    Integer int355 = 355;
+    @Contended
+    Integer int356 = 356;
+    @Contended
+    Integer int357 = 357;
+    @Contended
+    Integer int358 = 358;
+    @Contended
+    Integer int359 = 359;
+    @Contended
+    Integer int360 = 360;
+    @Contended
+    Integer int361 = 361;
+    @Contended
+    Integer int362 = 362;
+    @Contended
+    Integer int363 = 363;
+    @Contended
+    Integer int364 = 364;
+    @Contended
+    Integer int365 = 365;
+    @Contended
+    Integer int366 = 366;
+    @Contended
+    Integer int367 = 367;
+    @Contended
+    Integer int368 = 368;
+    @Contended
+    Integer int369 = 369;
+    @Contended
+    Integer int370 = 370;
+    @Contended
+    Integer int371 = 371;
+    @Contended
+    Integer int372 = 372;
+    @Contended
+    Integer int373 = 373;
+    @Contended
+    Integer int374 = 374;
+    @Contended
+    Integer int375 = 375;
+    @Contended
+    Integer int376 = 376;
+    @Contended
+    Integer int377 = 377;
+    @Contended
+    Integer int378 = 378;
+    @Contended
+    Integer int379 = 379;
+    @Contended
+    Integer int380 = 380;
+    @Contended
+    Integer int381 = 381;
+    @Contended
+    Integer int382 = 382;
+    @Contended
+    Integer int383 = 383;
+    @Contended
+    Integer int384 = 384;
+    @Contended
+    Integer int385 = 385;
+    @Contended
+    Integer int386 = 386;
+    @Contended
+    Integer int387 = 387;
+    @Contended
+    Integer int388 = 388;
+    @Contended
+    Integer int389 = 389;
+    @Contended
+    Integer int390 = 390;
+    @Contended
+    Integer int391 = 391;
+    @Contended
+    Integer int392 = 392;
+    @Contended
+    Integer int393 = 393;
+    @Contended
+    Integer int394 = 394;
+    @Contended
+    Integer int395 = 395;
+    @Contended
+    Integer int396 = 396;
+    @Contended
+    Integer int397 = 397;
+    @Contended
+    Integer int398 = 398;
+    @Contended
+    Integer int399 = 399;
+    @Contended
+    Integer int400 = 400;
+    @Contended
+    Integer int401 = 401;
+    @Contended
+    Integer int402 = 402;
+    @Contended
+    Integer int403 = 403;
+    @Contended
+    Integer int404 = 404;
+    @Contended
+    Integer int405 = 405;
+    @Contended
+    Integer int406 = 406;
+    @Contended
+    Integer int407 = 407;
+    @Contended
+    Integer int408 = 408;
+    @Contended
+    Integer int409 = 409;
+    @Contended
+    Integer int410 = 410;
+    @Contended
+    Integer int411 = 411;
+    @Contended
+    Integer int412 = 412;
+    @Contended
+    Integer int413 = 413;
+    @Contended
+    Integer int414 = 414;
+    @Contended
+    Integer int415 = 415;
+    @Contended
+    Integer int416 = 416;
+    @Contended
+    Integer int417 = 417;
+    @Contended
+    Integer int418 = 418;
+    @Contended
+    Integer int419 = 419;
+    @Contended
+    Integer int420 = 420;
+    @Contended
+    Integer int421 = 421;
+    @Contended
+    Integer int422 = 422;
+    @Contended
+    Integer int423 = 423;
+    @Contended
+    Integer int424 = 424;
+    @Contended
+    Integer int425 = 425;
+    @Contended
+    Integer int426 = 426;
+    @Contended
+    Integer int427 = 427;
+    @Contended
+    Integer int428 = 428;
+    @Contended
+    Integer int429 = 429;
+    @Contended
+    Integer int430 = 430;
+    @Contended
+    Integer int431 = 431;
+    @Contended
+    Integer int432 = 432;
+    @Contended
+    Integer int433 = 433;
+    @Contended
+    Integer int434 = 434;
+    @Contended
+    Integer int435 = 435;
+    @Contended
+    Integer int436 = 436;
+    @Contended
+    Integer int437 = 437;
+    @Contended
+    Integer int438 = 438;
+    @Contended
+    Integer int439 = 439;
+    @Contended
+    Integer int440 = 440;
+    @Contended
+    Integer int441 = 441;
+    @Contended
+    Integer int442 = 442;
+    @Contended
+    Integer int443 = 443;
+    @Contended
+    Integer int444 = 444;
+    @Contended
+    Integer int445 = 445;
+    @Contended
+    Integer int446 = 446;
+    @Contended
+    Integer int447 = 447;
+    @Contended
+    Integer int448 = 448;
+    @Contended
+    Integer int449 = 449;
+    @Contended
+    Integer int450 = 450;
+    @Contended
+    Integer int451 = 451;
+    @Contended
+    Integer int452 = 452;
+    @Contended
+    Integer int453 = 453;
+    @Contended
+    Integer int454 = 454;
+    @Contended
+    Integer int455 = 455;
+    @Contended
+    Integer int456 = 456;
+    @Contended
+    Integer int457 = 457;
+    @Contended
+    Integer int458 = 458;
+    @Contended
+    Integer int459 = 459;
+    @Contended
+    Integer int460 = 460;
+    @Contended
+    Integer int461 = 461;
+    @Contended
+    Integer int462 = 462;
+    @Contended
+    Integer int463 = 463;
+    @Contended
+    Integer int464 = 464;
+    @Contended
+    Integer int465 = 465;
+    @Contended
+    Integer int466 = 466;
+    @Contended
+    Integer int467 = 467;
+    @Contended
+    Integer int468 = 468;
+    @Contended
+    Integer int469 = 469;
+    @Contended
+    Integer int470 = 470;
+    @Contended
+    Integer int471 = 471;
+    @Contended
+    Integer int472 = 472;
+    @Contended
+    Integer int473 = 473;
+    @Contended
+    Integer int474 = 474;
+    @Contended
+    Integer int475 = 475;
+    @Contended
+    Integer int476 = 476;
+    @Contended
+    Integer int477 = 477;
+    @Contended
+    Integer int478 = 478;
+    @Contended
+    Integer int479 = 479;
+    @Contended
+    Integer int480 = 480;
+    static volatile Main480 instance;
+    public static void main(String[] args) {
+        int c = 0;
+        for (; c < 9000; c++) {
+            instance = new Main480();
+        }
+        System.out.println("Done all " + c + " iterations.");
+    }
+}

--- a/apps/quarkus-spöklik-encoding/src/main/docker/Dockerfile.native
+++ b/apps/quarkus-spöklik-encoding/src/main/docker/Dockerfile.native
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/apps/quarkus-vertx/src/main/docker/Dockerfile.native
+++ b/apps/quarkus-vertx/src/main/docker/Dockerfile.native
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10
 RUN microdnf --enablerepo=ubi-8-baseos-debug-rpms --enablerepo=ubi-8-appstream-debug-rpms install gdb zlib-debuginfo glibc-debuginfo
 WORKDIR /work/
 COPY target/quarkus-runner /work/application

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
                 <module>apps/reslocations</module>
                 <module>apps/timezones</module>
                 <module>apps/versions</module>
+                <module>apps/monitor-field-offset</module>
                 <module>testsuite</module>
             </modules>
         </profile>

--- a/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
@@ -790,7 +790,8 @@ public class AppReproducersTest {
             Logs.checkLog(cn, mn, app, processLog);
             processStopper(process, false);
             final Pattern pok = Pattern.compile(".*Done all 9000 iterations.*");
-            assertTrue(searchLogLines(pok, processLog, Charset.defaultCharset()), "Expected pattern " + pok + " was not found in the log.");
+            assertTrue(searchLogLines(pok, processLog, Charset.defaultCharset()), "Expected pattern " + pok + " was not found in the log." +
+                    "Perhaps ContendedPaddingWidth default has changed from 128 bytes to something else?");
 
             if (inContainer) {
                 removeContainers(app.runtimeContainer.name);

--- a/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
@@ -68,6 +68,7 @@ import static org.graalvm.tests.integration.utils.Commands.getBaseDir;
 import static org.graalvm.tests.integration.utils.Commands.getRunCommand;
 import static org.graalvm.tests.integration.utils.Commands.listStaticLibs;
 import static org.graalvm.tests.integration.utils.Commands.processStopper;
+import static org.graalvm.tests.integration.utils.Commands.removeContainers;
 import static org.graalvm.tests.integration.utils.Commands.runCommand;
 import static org.graalvm.tests.integration.utils.Commands.searchLogLines;
 import static org.graalvm.tests.integration.utils.Logs.getLogsDir;
@@ -745,7 +746,66 @@ public class AppReproducersTest {
             cleanup(process, cn, mn, report, app, processLog);
         }
     }
-    
+
+    @Test
+    @Tag("builder-image")
+    @IfMandrelVersion(minJDK = "21.0.3", inContainer = true)
+    public void monitorFieldOffsetContainerTest(TestInfo testInfo) throws IOException, InterruptedException {
+        monitorFieldOffset(testInfo, Apps.MONITOR_OFFSET_BUILDER_IMAGE);
+    }
+
+    @Test
+    @IfMandrelVersion(minJDK = "21.0.3")
+    public void monitorFieldOffsetTest(TestInfo testInfo) throws IOException, InterruptedException {
+        monitorFieldOffset(testInfo, Apps.MONITOR_OFFSET);
+    }
+
+    public void monitorFieldOffset(TestInfo testInfo, Apps app) throws IOException, InterruptedException {
+        LOGGER.info("Testing app: " + app);
+        Process process = null;
+        File processLog = null;
+        final StringBuilder report = new StringBuilder();
+        final File appDir = Path.of(BASE_DIR, app.dir).toFile();
+        final String cn = testInfo.getTestClass().get().getCanonicalName();
+        final String mn = testInfo.getTestMethod().get().getName();
+        final boolean inContainer = app == Apps.MONITOR_OFFSET_BUILDER_IMAGE;
+        try {
+            // Cleanup
+            cleanTarget(app);
+            if (inContainer) {
+                removeContainers(app.runtimeContainer.name);
+            }
+            Files.createDirectories(Paths.get(appDir.getAbsolutePath() + File.separator + "logs"));
+
+            // OK version
+            processLog = Path.of(appDir.getAbsolutePath(), "logs", "build-and-run.log").toFile();
+            builderRoutine(inContainer ? 3 : 2, app, report, cn, mn, appDir, processLog);
+            LOGGER.info("Running...");
+            final List<String> cmd = getRunCommand(app.buildAndRunCmds.cmds[app.buildAndRunCmds.cmds.length - 3]);
+            process = runCommand(cmd, appDir, processLog, app);
+            assertNotNull(process, "The test application failed to run. Check " + getLogsDir(cn, mn) + File.separator + processLog.getName());
+            process.waitFor(5, TimeUnit.SECONDS);
+            Logs.appendln(report, appDir.getAbsolutePath());
+            Logs.appendlnSection(report, String.join(" ", cmd));
+            Logs.checkLog(cn, mn, app, processLog);
+            processStopper(process, false);
+            final Pattern pok = Pattern.compile(".*Done all 9000 iterations.*");
+            assertTrue(searchLogLines(pok, processLog, Charset.defaultCharset()), "Expected pattern " + pok + " was not found in the log.");
+
+            if (inContainer) {
+                removeContainers(app.runtimeContainer.name);
+            }
+
+            // NOK version
+            builderRoutine(inContainer ? 4 : 3, app.buildAndRunCmds.cmds.length, app, report, cn, mn, appDir, processLog);
+            Logs.checkLog(cn, mn, app, processLog);
+            final Pattern pnok = Pattern.compile(".*Class monitor_field_offset.Main480 has an invalid monitor field offset.*");
+            assertTrue(searchLogLines(pnok, processLog, Charset.defaultCharset()), "Expected pattern " + pnok + " was not found in the log.");
+        } finally {
+            cleanup(process, cn, mn, report, app, processLog);
+        }
+    }
+
     @Test
     @Tag("calendars")
     @IfMandrelVersion(min = "22.3.5") // The fix for this test is in 22.3.5 and better

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/Apps.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/Apps.java
@@ -176,7 +176,17 @@ public enum Apps {
             URLContent.NONE,
             WhitelistLogLines.RESLOCATIONS,
             BuildAndRunCmds.RESLOCATIONS,
-            ContainerNames.NONE);
+            ContainerNames.NONE),
+    MONITOR_OFFSET("apps" + File.separator + "monitor-field-offset",
+            URLContent.NONE,
+            WhitelistLogLines.MONITOR_OFFSET,
+            BuildAndRunCmds.MONITOR_OFFSET,
+            ContainerNames.NONE),
+    MONITOR_OFFSET_BUILDER_IMAGE("apps" + File.separator + "monitor-field-offset",
+            URLContent.NONE,
+            WhitelistLogLines.MONITOR_OFFSET,
+            BuildAndRunCmds.MONITOR_OFFSET_BUILDER_IMAGE,
+            ContainerNames.MONITOR_OFFSET_BUILDER_IMAGE);
 
     public final String dir;
     public final URLContent urlContent;

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildAndRunCmds.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildAndRunCmds.java
@@ -376,6 +376,35 @@ public enum BuildAndRunCmds {
                     "-J--add-exports=java.desktop/com.sun.imageio.plugins.common=ALL-UNNAMED",
                     "-jar", "./target/reslocations.jar", "target/reslocations"},
             new String[]{IS_THIS_WINDOWS ? "target\\reslocations.exe" : "./target/reslocations"}
+    }),
+    MONITOR_OFFSET(new String[][] {
+            new String[] { "mvn", "package", "-POK" },
+            new String[] { "native-image", "-R:-InstallSegfaultHandler", "-march=native", "--gc=serial", "--no-fallback",
+                    "-jar", "target/monitor-field-offsets-ok.jar", "target/monitor-field-offsets-ok" },
+            new String[] { IS_THIS_WINDOWS ? "target\\monitor-field-offsets-ok" : "./target/monitor-field-offsets-ok" },
+            new String[] { "mvn", "package", "-PNOK" },
+            new String[] { "native-image", "-R:-InstallSegfaultHandler", "-march=native", "--gc=serial", "--no-fallback",
+                    "-jar", "target/monitor-field-offsets-nok.jar", "target/monitor-field-offsets-nok" }
+    }),
+    MONITOR_OFFSET_BUILDER_IMAGE(new String[][] {
+            new String[] { "mvn", "package", "-POK" },
+            new String[] {
+                    CONTAINER_RUNTIME, "run", "-u", IS_THIS_WINDOWS ? "" : getUnixUIDGID(),
+                    "-t", "-v", BASE_DIR + File.separator + "apps" + File.separator + "monitor-field-offset:/project:z",
+                    "--name", ContainerNames.MONITOR_OFFSET_BUILDER_IMAGE.name,
+                    BUILDER_IMAGE, "-R:-InstallSegfaultHandler", "-march=native", "--gc=serial", "--no-fallback",
+                    "-jar", "target/monitor-field-offsets-ok.jar", "target/monitor-field-offsets-ok" },
+            new String[]{CONTAINER_RUNTIME, "build", "--network=host", "-t", ContainerNames.MONITOR_OFFSET_BUILDER_IMAGE.name, "."},
+            new String[] { CONTAINER_RUNTIME, "run", IS_THIS_WINDOWS ? "" : "-u", IS_THIS_WINDOWS ? "" : getUnixUIDGID(),
+                    "-t", "-v", BASE_DIR + File.separator + "apps" + File.separator + "monitor-field-offset:/work:z",
+                    ContainerNames.MONITOR_OFFSET_BUILDER_IMAGE.name, "target/monitor-field-offsets-ok" },
+            new String[] { "mvn", "package", "-PNOK" },
+            new String[] {
+                    CONTAINER_RUNTIME, "run", "-u", IS_THIS_WINDOWS ? "" : getUnixUIDGID(),
+                    "-t", "-v", BASE_DIR + File.separator + "apps" + File.separator + "monitor-field-offset:/project:z",
+                    "--name", ContainerNames.MONITOR_OFFSET_BUILDER_IMAGE.name,
+                    BUILDER_IMAGE, "-R:-InstallSegfaultHandler", "-march=native", "--gc=serial", "--no-fallback",
+                    "-jar", "target/monitor-field-offsets-nok.jar", "target/monitor-field-offsets-nok" },
     });
 
     public final String[][] cmds;

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/Commands.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/Commands.java
@@ -1117,14 +1117,14 @@ public class Commands {
      *               "-Dcustom.final.name=quarkus-json_-ParseOnce"},
      * //@formatter:on
      */
-    public static void builderRoutine(int steps, Apps app, StringBuilder report, String cn, String mn, File appDir,
+    public static void builderRoutine(int startIndexInclusive, int endIndexExclusive, Apps app, StringBuilder report, String cn, String mn, File appDir,
                                       File processLog, Map<String, String> env, Map<String, String> switchReplacements) throws IOException {
         // The last command is reserved for running it
         assertTrue(app.buildAndRunCmds.cmds.length > 1);
         if (report != null) {
             Logs.appendln(report, "# " + cn + ", " + mn);
         }
-        for (int i = 0; i < steps; i++) {
+        for (int i = startIndexInclusive; i < endIndexExclusive; i++) {
             // We cannot run commands in parallel, we need them to follow one after another
             final ExecutorService buildService = Executors.newFixedThreadPool(1);
             final List<String> cmd;
@@ -1147,15 +1147,25 @@ public class Commands {
     }
 
     public static void builderRoutine(Apps app, StringBuilder report, String cn, String mn, File appDir, File processLog) throws IOException {
-        builderRoutine(app.buildAndRunCmds.cmds.length - 1, app, report, cn, mn, appDir, processLog, null, null);
+        builderRoutine(0, app.buildAndRunCmds.cmds.length - 1, app, report, cn, mn, appDir, processLog, null, null);
     }
 
     public static void builderRoutine(Apps app, StringBuilder report, String cn, String mn, File appDir, File processLog, Map<String, String> env) throws IOException {
-        builderRoutine(app.buildAndRunCmds.cmds.length - 1, app, report, cn, mn, appDir, processLog, env, null);
+        builderRoutine(0, app.buildAndRunCmds.cmds.length - 1, app, report, cn, mn, appDir, processLog, env, null);
     }
 
-    public static void builderRoutine(int steps, Apps app, StringBuilder report, String cn, String mn, File appDir, File processLog) throws IOException {
-        builderRoutine(steps, app, report, cn, mn, appDir, processLog, null, null);
+    public static void builderRoutine(int endIndexExclusive, Apps app, StringBuilder report, String cn, String mn, File appDir, File processLog) throws IOException {
+        builderRoutine(0, endIndexExclusive, app, report, cn, mn, appDir, processLog, null, null);
+    }
+
+    public static void builderRoutine(int endIndexExclusive, Apps app, StringBuilder report, String cn, String mn, File appDir,
+            File processLog, Map<String, String> env, Map<String, String> switchReplacements) throws IOException {
+        builderRoutine(0, endIndexExclusive, app, report, cn, mn, appDir, processLog, env, switchReplacements);
+
+    }
+
+    public static void builderRoutine(int startIndexInclusive, int endIndexExclusive, Apps app, StringBuilder report, String cn, String mn, File appDir, File processLog) throws IOException {
+        builderRoutine(startIndexInclusive, endIndexExclusive, app, report, cn, mn, appDir, processLog, null, null);
     }
 
     public static List<String> replaceSwitchesInCmd(final List<String> cmd, final Map<String, String> switchReplacements) {
@@ -1267,6 +1277,9 @@ public class Commands {
         // Archive logs no matter what
         for (File f : log) {
             Logs.archiveLog(cn, mn, f);
+        }
+        if (app.runtimeContainer != ContainerNames.NONE) {
+            removeContainers(app.runtimeContainer.name);
         }
         Logs.writeReport(cn, mn, report.toString());
         cleanTarget(app);

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/ContainerNames.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/ContainerNames.java
@@ -32,6 +32,7 @@ public enum ContainerNames {
     JFR_PERFORMANCE_BUILDER_IMAGE("my-jfr-performance-runner"),
     JFR_PLAINTEXT_BUILDER_IMAGE("my-jfr-plaintext-runner"),
     HYPERFOIL("hyperfoil-container"),
+    MONITOR_OFFSET_BUILDER_IMAGE("my-monitor-offset-runner"),
     NONE("NO_CONTAINER");
 
     public final String name;

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
@@ -303,6 +303,17 @@ public enum WhitelistLogLines {
                     Pattern.compile(".*com\\.sun\\.imageio\\.plugins\\.common.*is internal proprietary API and may be removed in a future release.*")
             };
         }
+    },
+    MONITOR_OFFSET {
+        @Override
+        public Pattern[] get(boolean inContainer) {
+            return new Pattern[]{
+                    Pattern.compile(".*Failed generating.*"),
+                    Pattern.compile(".*The build process encountered an unexpected error.*"),
+                    Pattern.compile(".*monitor_field_offset.Main480 has an invalid monitor field offset.*"),
+                    Pattern.compile(".*error report at:.*"),
+            };
+        }
     };
 
     public abstract Pattern[] get(boolean inContainer);


### PR DESCRIPTION
Adds a test guarding against a possible regression in future. The compiler should not allow you to compile an unsupported source file. There was no warning in older versions and there is one now.

Tested on Linux amd64, aarch64 and MacOS aarch64 so far prior opening the PR.