### PR TITLE
ImageIO requires -H:+ForeignAPISupport to try to lookup fonts

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
@@ -56,11 +56,12 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.graalvm.tests.integration.DebugSymbolsTest.DebugOptions.DebugCodeInfoUseSourceMappings_23_0;
-import static org.graalvm.tests.integration.DebugSymbolsTest.DebugOptions.LockExperimentalVMOptions_23_1;
-import static org.graalvm.tests.integration.DebugSymbolsTest.DebugOptions.OmitInlinedMethodDebugLineInfo_23_0;
-import static org.graalvm.tests.integration.DebugSymbolsTest.DebugOptions.TrackNodeSourcePosition_23_0;
-import static org.graalvm.tests.integration.DebugSymbolsTest.DebugOptions.UnlockExperimentalVMOptions_23_1;
+import static org.graalvm.tests.integration.utils.AuxiliaryOptions.DebugCodeInfoUseSourceMappings_23_0;
+import static org.graalvm.tests.integration.utils.AuxiliaryOptions.ForeignAPISupport_24_2;
+import static org.graalvm.tests.integration.utils.AuxiliaryOptions.LockExperimentalVMOptions_23_1;
+import static org.graalvm.tests.integration.utils.AuxiliaryOptions.OmitInlinedMethodDebugLineInfo_23_0;
+import static org.graalvm.tests.integration.utils.AuxiliaryOptions.TrackNodeSourcePosition_23_0;
+import static org.graalvm.tests.integration.utils.AuxiliaryOptions.UnlockExperimentalVMOptions_23_1;
 import static org.graalvm.tests.integration.utils.Commands.builderRoutine;
 import static org.graalvm.tests.integration.utils.Commands.cleanTarget;
 import static org.graalvm.tests.integration.utils.Commands.cleanup;
@@ -524,7 +525,8 @@ public class AppReproducersTest {
             // Build
             processLog = Path.of(appDir.getAbsolutePath(), "logs", "build-and-run.log").toFile();
 
-            builderRoutine(app, report, cn, mn, appDir, processLog);
+            builderRoutine(0, app.buildAndRunCmds.cmds.length - 1,
+                    app, report, cn, mn, appDir, processLog, null, getSwitches(app));
 
             // Record images' hashsums as created by a Java process
             final List<String> errors = new ArrayList<>(12);
@@ -1055,6 +1057,11 @@ public class AppReproducersTest {
             switches.put(TrackNodeSourcePosition_23_0.token, "");
             switches.put(DebugCodeInfoUseSourceMappings_23_0.token, "");
             switches.put(OmitInlinedMethodDebugLineInfo_23_0.token, "");
+        }
+        if (version.compareTo(Version.create(24, 2, 0)) >= 0) {
+            switches.put(ForeignAPISupport_24_2.token, ForeignAPISupport_24_2.replacement);
+        } else {
+            switches.put(ForeignAPISupport_24_2.token, "");
         }
         return switches;
     }

--- a/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
@@ -610,31 +610,40 @@ public class AppReproducersTest {
 
             // Test static libs in the executable
             final File executable = new File(appDir.getAbsolutePath() + File.separator + "target", "imageio");
-            Set<String> expected = Set.of("libawt.a", "libawt_headless.a", "libfdlibm.a", "libfontmanager.a", "libjava.a", "libjavajpeg.a", "libjvm.a", "liblcms.a", "liblibchelper.a", "libnet.a", "libnio.a", "libzip.a");
+            final Set<String> expected = new HashSet<>();
+            expected.add("libawt.a");
+            expected.add("libawt_headless.a");
+            expected.add("libfdlibm.a");
+            expected.add("libfontmanager.a");
+            expected.add("libjava.a");
+            expected.add("libjavajpeg.a");
+            expected.add("libjvm.a");
+            expected.add("liblcms.a");
+            expected.add("liblibchelper.a");
+            expected.add("libnet.a");
+            expected.add("libnio.a");
+            expected.add("libzip.a");
+            if (UsedVersion.getVersion(inContainer).compareTo(Version.parse("24.2")) >= 0) {
+                expected.add("libsvm_container.a");
+            }
             if (UsedVersion.getVersion(inContainer).compareTo(Version.parse("23.0")) >= 0) {
                 // The set of static libs for imageio is smaller beginning with Mandrel 23+ as
                 // it has dynamic AWT support.
-                Set<String> modifiable = new HashSet<>(expected);
-                modifiable.remove("libawt_headless.a");
-                modifiable.remove("libfontmanager.a");
-                modifiable.remove("libjavajpeg.a");
-                modifiable.remove("liblcms.a");
-                modifiable.remove("libawt.a");
-                expected = Collections.unmodifiableSet(modifiable);
+                expected.remove("libawt_headless.a");
+                expected.remove("libfontmanager.a");
+                expected.remove("libjavajpeg.a");
+                expected.remove("liblcms.a");
+                expected.remove("libawt.a");
             }
             if (UsedVersion.jdkFeature(inContainer) >= 21) {
                 // JDK 21 has fdlibm ported to Java. See JDK-8171407
-                Set<String> modifiable = new HashSet<>(expected);
-                modifiable.remove("libfdlibm.a");
-                expected = Collections.unmodifiableSet(modifiable);
+                expected.remove("libfdlibm.a");
             }
             if (UsedVersion.jdkFeature(inContainer) > 11 || (UsedVersion.jdkFeature(inContainer) == 11 && UsedVersion.jdkUpdate(inContainer) > 12)) {
                 // Harfbuzz removed: https://github.com/graalvm/mandrel/issues/286
                 // NO-OP
             } else {
-                Set<String> modifiable = new HashSet<>(expected);
-                modifiable.add("libharfbuzz.a");
-                expected = Collections.unmodifiableSet(modifiable);
+                expected.add("libharfbuzz.a");
             }
 
             final Set<String> actual = listStaticLibs(executable);

--- a/testsuite/src/it/java/org/graalvm/tests/integration/DebugSymbolsTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/DebugSymbolsTest.java
@@ -56,11 +56,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-import static org.graalvm.tests.integration.DebugSymbolsTest.DebugOptions.DebugCodeInfoUseSourceMappings_23_0;
-import static org.graalvm.tests.integration.DebugSymbolsTest.DebugOptions.LockExperimentalVMOptions_23_1;
-import static org.graalvm.tests.integration.DebugSymbolsTest.DebugOptions.OmitInlinedMethodDebugLineInfo_23_0;
-import static org.graalvm.tests.integration.DebugSymbolsTest.DebugOptions.TrackNodeSourcePosition_23_0;
-import static org.graalvm.tests.integration.DebugSymbolsTest.DebugOptions.UnlockExperimentalVMOptions_23_1;
+import static org.graalvm.tests.integration.utils.AuxiliaryOptions.DebugCodeInfoUseSourceMappings_23_0;
+import static org.graalvm.tests.integration.utils.AuxiliaryOptions.LockExperimentalVMOptions_23_1;
+import static org.graalvm.tests.integration.utils.AuxiliaryOptions.OmitInlinedMethodDebugLineInfo_23_0;
+import static org.graalvm.tests.integration.utils.AuxiliaryOptions.TrackNodeSourcePosition_23_0;
+import static org.graalvm.tests.integration.utils.AuxiliaryOptions.UnlockExperimentalVMOptions_23_1;
 import static org.graalvm.tests.integration.utils.Commands.CMD_DEFAULT_TIMEOUT_MS;
 import static org.graalvm.tests.integration.utils.Commands.CMD_LONG_TIMEOUT_MS;
 import static org.graalvm.tests.integration.utils.Commands.CONTAINER_RUNTIME;
@@ -98,22 +98,6 @@ public class DebugSymbolsTest {
 
     // GOTO i.e. accessing a URL of a debugged test app to trigger a certain code path
     private static final long GOTO_URL_SLEEP_MS = 50;
-
-    public enum DebugOptions {
-        UnlockExperimentalVMOptions_23_1("<DEBUG_FLAGS_23_1_a>", "-H:+UnlockExperimentalVMOptions"),
-        LockExperimentalVMOptions_23_1("<DEBUG_FLAGS_23_1_b>", "-H:-UnlockExperimentalVMOptions"),
-        TrackNodeSourcePosition_23_0("<DEBUG_FLAGS_23_0_a>", "-H:+TrackNodeSourcePosition"),
-        DebugCodeInfoUseSourceMappings_23_0("<DEBUG_FLAGS_23_0_b>", "-H:+DebugCodeInfoUseSourceMappings"),
-        OmitInlinedMethodDebugLineInfo_23_0("<DEBUG_FLAGS_23_0_c>", "-H:+OmitInlinedMethodDebugLineInfo");
-
-        public final String token;
-        final String replacement;
-
-        DebugOptions(String token, String replacement) {
-            this.token = token;
-            this.replacement = replacement;
-        }
-    }
 
     @Test
     @Tag("debugSymbolsSmoke")

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/AuxiliaryOptions.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/AuxiliaryOptions.java
@@ -1,0 +1,18 @@
+package org.graalvm.tests.integration.utils;
+
+public enum AuxiliaryOptions {
+    UnlockExperimentalVMOptions_23_1("<DEBUG_FLAGS_23_1_a>", "-H:+UnlockExperimentalVMOptions"),
+    LockExperimentalVMOptions_23_1("<DEBUG_FLAGS_23_1_b>", "-H:-UnlockExperimentalVMOptions"),
+    TrackNodeSourcePosition_23_0("<DEBUG_FLAGS_23_0_a>", "-H:+TrackNodeSourcePosition"),
+    DebugCodeInfoUseSourceMappings_23_0("<DEBUG_FLAGS_23_0_b>", "-H:+DebugCodeInfoUseSourceMappings"),
+    OmitInlinedMethodDebugLineInfo_23_0("<DEBUG_FLAGS_23_0_c>", "-H:+OmitInlinedMethodDebugLineInfo"),
+    ForeignAPISupport_24_2("<FFAPI>", "-H:+ForeignAPISupport");
+
+    public final String token;
+    public final String replacement;
+
+    AuxiliaryOptions(String token, String replacement) {
+        this.token = token;
+        this.replacement = replacement;
+    }
+}

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildAndRunCmds.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildAndRunCmds.java
@@ -19,8 +19,6 @@
  */
 package org.graalvm.tests.integration.utils;
 
-import org.graalvm.tests.integration.DebugSymbolsTest;
-
 import java.io.File;
 
 import static org.graalvm.tests.integration.AppReproducersTest.BASE_DIR;
@@ -29,6 +27,12 @@ import static org.graalvm.tests.integration.JFRTest.JFR_MONITORING_SWITCH_TOKEN;
 import static org.graalvm.tests.integration.PerfCheckTest.FINAL_NAME_TOKEN;
 import static org.graalvm.tests.integration.PerfCheckTest.MX_HEAP_MB;
 import static org.graalvm.tests.integration.PerfCheckTest.NATIVE_IMAGE_XMX_GB;
+import static org.graalvm.tests.integration.utils.AuxiliaryOptions.DebugCodeInfoUseSourceMappings_23_0;
+import static org.graalvm.tests.integration.utils.AuxiliaryOptions.ForeignAPISupport_24_2;
+import static org.graalvm.tests.integration.utils.AuxiliaryOptions.LockExperimentalVMOptions_23_1;
+import static org.graalvm.tests.integration.utils.AuxiliaryOptions.OmitInlinedMethodDebugLineInfo_23_0;
+import static org.graalvm.tests.integration.utils.AuxiliaryOptions.TrackNodeSourcePosition_23_0;
+import static org.graalvm.tests.integration.utils.AuxiliaryOptions.UnlockExperimentalVMOptions_23_1;
 import static org.graalvm.tests.integration.utils.Commands.BUILDER_IMAGE;
 import static org.graalvm.tests.integration.utils.Commands.CONTAINER_RUNTIME;
 import static org.graalvm.tests.integration.utils.Commands.GRAALVM_BUILD_OUTPUT_JSON_FILE;
@@ -209,7 +213,8 @@ public enum BuildAndRunCmds {
             new String[]{"mvn", "clean", "package"},
             new String[]{"java", "-Djava.awt.headless=true", "-agentlib:native-image-agent=config-output-dir=src/main/resources/META-INF/native-image", "-jar", "target/imageio.jar"},
             new String[]{"jar", "uf", "target/imageio.jar", "-C", "src/main/resources/", "META-INF"},
-            new String[]{"native-image", "-J-Djava.awt.headless=true", "--no-fallback", "-jar", "target/imageio.jar", "target/imageio"},
+            new String[]{"native-image", UnlockExperimentalVMOptions_23_1.token, ForeignAPISupport_24_2.token, LockExperimentalVMOptions_23_1.token,
+                    "-J-Djava.awt.headless=true", "--no-fallback", "-jar", "target/imageio.jar", "target/imageio"},
             new String[]{IS_THIS_WINDOWS ? "target\\imageio.exe" : "./target/imageio", "-Djava.home=.", "-Djava.awt.headless=true"}
     }),
     IMAGEIO_BUILDER_IMAGE(new String[][]{
@@ -229,7 +234,7 @@ public enum BuildAndRunCmds {
             // Native image build itself (jar was updated with properties in the previous step)
             new String[]{CONTAINER_RUNTIME, "run", IS_THIS_WINDOWS ? "" : "-u", IS_THIS_WINDOWS ? "" : getUnixUIDGID(),
                     "-t", "-v", BASE_DIR + File.separator + "apps" + File.separator + "imageio:/project:z",
-                    BUILDER_IMAGE,
+                    BUILDER_IMAGE, UnlockExperimentalVMOptions_23_1.token, ForeignAPISupport_24_2.token, LockExperimentalVMOptions_23_1.token,
                     "-J-Djava.awt.headless=true", "--no-fallback", "-jar", "target/imageio.jar", "target/imageio"},
             // We build a runtime image, ubi 8 minimal based, runtime dependencies installed
             new String[]{CONTAINER_RUNTIME, "build", "--network=host", "-t", ContainerNames.IMAGEIO_BUILDER_IMAGE.name, "."},
@@ -246,12 +251,12 @@ public enum BuildAndRunCmds {
                     :
                     new String[]{"unzip", "test_data.txt.zip", "-d", "target"},
 
-            new String[] { "native-image", DebugSymbolsTest.DebugOptions.UnlockExperimentalVMOptions_23_1.token,
+            new String[] { "native-image", UnlockExperimentalVMOptions_23_1.token,
                     "-H:GenerateDebugInfo=" + (IS_THIS_MACOS ? "0" : "1"), "-H:+PreserveFramePointer", "-H:-DeleteLocalSymbols",
-                    DebugSymbolsTest.DebugOptions.TrackNodeSourcePosition_23_0.token,
-                    DebugSymbolsTest.DebugOptions.DebugCodeInfoUseSourceMappings_23_0.token,
-                    DebugSymbolsTest.DebugOptions.OmitInlinedMethodDebugLineInfo_23_0.token,
-                    DebugSymbolsTest.DebugOptions.LockExperimentalVMOptions_23_1.token,
+                    TrackNodeSourcePosition_23_0.token,
+                    DebugCodeInfoUseSourceMappings_23_0.token,
+                    OmitInlinedMethodDebugLineInfo_23_0.token,
+                    LockExperimentalVMOptions_23_1.token,
                     "-jar", "target/debug-symbols-smoke.jar", "target/debug-symbols-smoke" },
             new String[]{"java", "-jar", "./target/debug-symbols-smoke.jar"},
             new String[]{IS_THIS_WINDOWS ? "target\\debug-symbols-smoke.exe" : "./target/debug-symbols-smoke"}

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
@@ -83,7 +83,9 @@ public enum WhitelistLogLines {
                     // org.jfree.jfreesvg reflectively accesses com.orsoncharts.Chart3DHints which is not on the classpath
                     Pattern.compile("Warning: Could not resolve .*com.orsoncharts.Chart3DHints for reflection configuration. Reason: java.lang.ClassNotFoundException: com.orsoncharts.Chart3DHints."),
                     // The java agent erroneously produces a reflection config mentioning this constructor, which doesn't exist
-                    Pattern.compile("Warning: Method sun\\.security\\.provider\\.NativePRNG\\.<init>\\(SecureRandomParameters\\) not found.")
+                    Pattern.compile("Warning: Method sun\\.security\\.provider\\.NativePRNG\\.<init>\\(SecureRandomParameters\\) not found."),
+                    // https://github.com/graalvm/mandrel/issues/760
+                    Pattern.compile(".*Warning: Option 'DynamicProxyConfigurationResources' is deprecated.*"),
             };
         }
     },


### PR DESCRIPTION
Surpasses #276 
Fixes #262 

@jerboaa So, this is unrelated to https://github.com/oracle/graal/issues/9300. JDK 24 with Graal master now requires `-H:+ForeignAPISupport`. I will have to take a look at it in Quarkus too.

```
Exception in thread "main" java.io.IOException: Problem reading font data.
    at java.desktop@24-internal/java.awt.Font.createFont0(Font.java:1205)
    at java.desktop@24-internal/java.awt.Font.createFont(Font.java:1076)
    at imageio.Main.loadFonts(Main.java:139)
    at imageio.Main.paintRectangles(Main.java:97)
    at imageio.Main.main(Main.java:195)
    at java.base@24-internal/java.lang.invoke.LambdaForm$DMH/sa346b79c.invokeStaticInit(LambdaForm$DMH)
Caused by: com.oracle.svm.core.jdk.UnsupportedFeatureError: Support for the Java Foreign Function and Memory API is not active: enable with -H:+ForeignAPISupport
    at org.graalvm.nativeimage.builder/com.oracle.svm.core.util.VMError.unsupportedFeature(VMError.java:121)
    at org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.ForeignDisabledSubstitutions.fail(ForeignDisabledSubstitutions.java:175)
    at java.base@24-internal/jdk.internal.foreign.layout.AbstractLayout.varHandle(AbstractLayout.java:152)
    at java.desktop@24-internal/sun.font.StrikeCache.getVarHandle(StrikeCache.java:134)
    at java.desktop@24-internal/sun.font.StrikeCache.<clinit>(StrikeCache.java:139)
    at java.desktop@24-internal/sun.font.PhysicalStrike.<clinit>(PhysicalStrike.java:41)
    at java.base@24-internal/java.lang.Class.ensureInitialized(DynamicHub.java:655)
    at org.graalvm.nativeimage.builder/com.oracle.svm.core.jni.functions.JNIFunctions.FindClass(JNIFunctions.java:374)
    at java.desktop@24-internal/sun.font.SunFontManager.initIDs(Native Method)
    at java.desktop@24-internal/sun.font.SunFontManager$1.run(SunFontManager.java:273)
    at java.desktop@24-internal/sun.font.SunFontManager$1.run(SunFontManager.java:267)
    at java.base@24-internal/java.security.AccessController.executePrivileged(AccessController.java:132)
    at java.base@24-internal/java.security.AccessController.doPrivileged(AccessController.java:319)
    at java.desktop@24-internal/sun.font.SunFontManager.initStatic(SunFontManager.java:267)
    at java.desktop@24-internal/sun.font.SunFontManager.<clinit>(SunFontManager.java:262)
    at java.base@24-internal/java.lang.Class.ensureInitialized(DynamicHub.java:655)
    at java.base@24-internal/java.lang.Class.ensureInitialized(DynamicHub.java:655)
    at java.desktop@24-internal/sun.font.PlatformFontInfo.createFontManager(PlatformFontInfo.java:37)
    at java.desktop@24-internal/sun.font.FontManagerFactory.getInstance(FontManagerFactory.java:51)
    at java.desktop@24-internal/java.awt.Font.createFont0(Font.java:1167)

```

With vanilla JDK, you don't see this whole stacktrace, you just see unhelpful:

```
Exception in thread "main" java.io.IOException: Problem reading font data.
    at java.desktop@24-beta/java.awt.Font.createFont0(Font.java:1205)
    at java.desktop@24-beta/java.awt.Font.createFont(Font.java:1076)
    at imageio.Main.loadFonts(Main.java:139)
    at imageio.Main.paintRectangles(Main.java:97)
    at imageio.Main.main(Main.java:195)
    at java.base@24-beta/java.lang.invoke.LambdaForm$DMH/sa346b79c.invokeStaticInit(LambdaForm$DMH)
```

That is because of this in JDK:
```
--- a/src/java.desktop/share/classes/java/awt/Font.java
+++ b/src/java.desktop/share/classes/java/awt/Font.java
@@ -1202,7 +1202,7 @@ public Void run() {
             if (cause instanceof FontFormatException) {
                 throw (FontFormatException)cause;
             }
-            throw new IOException("Problem reading font data.");
+            throw new IOException("Problem reading font data.", t);
         }
     }
 
~
```

