### PR TITLE
Update version range for Serialization tests

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
@@ -819,26 +819,26 @@ public class AppReproducersTest {
 
     @Test
     @Tag("builder-image")
-    @IfMandrelVersion(min = "23.1.5", maxJDK = "21.0.999", inContainer = true)
+    @IfMandrelVersion(min = "23.1.5", max = "23.1.999", inContainer = true)
     public void forSerializationContainer21Test(TestInfo testInfo) throws IOException, InterruptedException {
         forSerialization(testInfo, Apps.FOR_SERIALIZATION_BUILDER_IMAGE);
     }
 
     @Test
-    @IfMandrelVersion(min = "23.1.5", maxJDK = "21.0.999")
+    @IfMandrelVersion(min = "23.1.5", max = "23.1.999")
     public void forSerialization21Test(TestInfo testInfo) throws IOException, InterruptedException {
         forSerialization(testInfo, Apps.FOR_SERIALIZATION);
     }
 
     @Test
     @Tag("builder-image")
-    @IfMandrelVersion(min = "23.1.5", minJDK = "23", inContainer = true)
+    @IfMandrelVersion(min = "24.2.0", inContainer = true)
     public void forSerializationContainer23Test(TestInfo testInfo) throws IOException, InterruptedException {
         forSerialization(testInfo, Apps.FOR_SERIALIZATION_BUILDER_IMAGE);
     }
 
     @Test
-    @IfMandrelVersion(min = "23.1.5", minJDK = "23")
+    @IfMandrelVersion(min = "24.2.0")
     public void forSerialization23Test(TestInfo testInfo) throws IOException, InterruptedException {
         forSerialization(testInfo, Apps.FOR_SERIALIZATION);
     }


### PR DESCRIPTION
https://github.com/oracle/graal/pull/9091 is only present in >= 24.2 (GraalVM for JDK 24) and
23.1.xxx (GraalVM for JDK 21)

Both 24.0 and 24.1 don't include the fix and are expected to fail.

See https://github.com/graalvm/mandrel/actions/runs/10908619717/job/30276316555