### PR TITLE
Disable String[] check in serialization test

### DIFF
--- a/apps/for-serialization/src/main/java/for_serialization/Main.java
+++ b/apps/for-serialization/src/main/java/for_serialization/Main.java
@@ -93,8 +93,8 @@ public class Main {
                 Long[][].class,
                 Short[].class,
                 Short[][].class,
-                // https://github.com/oracle/graal/issues/9581
-                String[].class,
+                // Disabled till https://github.com/oracle/graal/issues/9581 gets resolved
+                // String[].class,
                 String[][].class,
                 Void[].class,
                 Void[][].class,

--- a/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
@@ -820,26 +820,26 @@ public class AppReproducersTest {
     @Test
     @Tag("builder-image")
     @IfMandrelVersion(min = "23.1.5", max = "23.1.999", inContainer = true)
-    public void forSerializationContainer21Test(TestInfo testInfo) throws IOException, InterruptedException {
+    public void forSerializationContainer23_1Test(TestInfo testInfo) throws IOException, InterruptedException {
         forSerialization(testInfo, Apps.FOR_SERIALIZATION_BUILDER_IMAGE);
     }
 
     @Test
     @IfMandrelVersion(min = "23.1.5", max = "23.1.999")
-    public void forSerialization21Test(TestInfo testInfo) throws IOException, InterruptedException {
+    public void forSerialization23_1Test(TestInfo testInfo) throws IOException, InterruptedException {
         forSerialization(testInfo, Apps.FOR_SERIALIZATION);
     }
 
     @Test
     @Tag("builder-image")
     @IfMandrelVersion(min = "24.2.0", inContainer = true)
-    public void forSerializationContainer23Test(TestInfo testInfo) throws IOException, InterruptedException {
+    public void forSerializationContainerPost24_2Test(TestInfo testInfo) throws IOException, InterruptedException {
         forSerialization(testInfo, Apps.FOR_SERIALIZATION_BUILDER_IMAGE);
     }
 
     @Test
     @IfMandrelVersion(min = "24.2.0")
-    public void forSerialization23Test(TestInfo testInfo) throws IOException, InterruptedException {
+    public void forSerializationPost24_2Test(TestInfo testInfo) throws IOException, InterruptedException {
         forSerialization(testInfo, Apps.FOR_SERIALIZATION);
     }
 


### PR DESCRIPTION
Works around https://github.com/oracle/graal/issues/9581 to [avoid CI noise](https://github.com/Karm/mandrel-integration-tests/issues/282#issuecomment-2376449083)
