### PR TITLE
Fix AppReproducersTest#timezonesBakedIn

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildAndRunCmds.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildAndRunCmds.java
@@ -22,6 +22,8 @@ package org.graalvm.tests.integration.utils;
 import java.io.File;
 
 import static org.graalvm.tests.integration.AppReproducersTest.BASE_DIR;
+import static org.graalvm.tests.integration.AppReproducersTest.LOCALEINCLUDES_TOKEN_1;
+import static org.graalvm.tests.integration.AppReproducersTest.LOCALEINCLUDES_TOKEN_2;
 import static org.graalvm.tests.integration.JFRTest.JFR_FLIGHT_RECORDER_HOTSPOT_TOKEN;
 import static org.graalvm.tests.integration.JFRTest.JFR_MONITORING_SWITCH_TOKEN;
 import static org.graalvm.tests.integration.PerfCheckTest.FINAL_NAME_TOKEN;
@@ -191,7 +193,7 @@ public enum BuildAndRunCmds {
     }),
     TIMEZONES(new String[][]{
             new String[]{"mvn", "package"},
-            new String[]{"native-image", "-J-Duser.country=CA", "-J-Duser.language=fr", "-jar", "target/timezones.jar", "target/timezones"},
+            new String[]{"native-image", LOCALEINCLUDES_TOKEN_1, LOCALEINCLUDES_TOKEN_2, "-jar", "target/timezones.jar", "target/timezones"},
             new String[]{IS_THIS_WINDOWS ? "target\\timezones.exe" : "./target/timezones"}
     }),
     CALENDARS(new String[][]{


### PR DESCRIPTION
With GraalVM prior to `24.2.0` the default locale (and included locale) for a native image was determined by the -Duser.language and -Duser.country settings as image build time. With GraalVM `>= 24.2.0` the build settings of language/country have no effect in terms of included locales in the resulting native image. Therefore, `-H:IncludeLocales`, needs to be used at build time instead. Also at image runtime the default language is determined by the system locale. For the purpose of the test we'd want the French language which we need to set at image runtime when the test runs.

Tested with `GraalVM community 23+37` (which uses the old scheme) and with a latest JDK 24-based mandrel build which uses the new scheme. Both pass.

24.1:
```
[...]
Command: native-image -J-Duser.country=CA -J-Duser.language=fr -jar target/timezones.jar target/timezones
[...]
Command: ./target/timezones
jeu. sept. 26 12:48:51 CEST 2024
heure normale de l’Europe centrale
```

24.2
```
[...]
Command: native-image -H:IncludeLocales=fr-CA -jar target/timezones.jar target/timezones
[...]
Command: ./target/timezones -Duser.language=fr
jeu. sept. 26 12:53:57 CEST 2024
heure normale d’Europe centrale
```

Closes: #285