### PR TITLE
Race condition with RHEL9 Podman version, Whitelists, Thresholds

### DIFF
--- a/apps/quarkus-spöklik-encoding/threshold.conf
+++ b/apps/quarkus-spöklik-encoding/threshold.conf
@@ -20,4 +20,7 @@ linux.container.time.to.first.ok.request.threshold.ms=1500
 linux.container.RSS.threshold.kB=55000
 @IfQuarkusVersion(min ="3.7.0")
 linux.container.executable.size.threshold.kB=51313
-
+@IfQuarkusVersion(min ="3.8.6")
+linux.container.executable.size.threshold.kB=51991
+@IfQuarkusVersion(min ="3.15.1")
+linux.container.executable.size.threshold.kB=52860

--- a/testsuite/src/it/java/org/graalvm/tests/integration/RuntimesSmokeTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/RuntimesSmokeTest.java
@@ -42,6 +42,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 import static org.graalvm.tests.integration.utils.Commands.QUARKUS_VERSION;
@@ -59,6 +60,7 @@ import static org.graalvm.tests.integration.utils.Commands.removeContainer;
 import static org.graalvm.tests.integration.utils.Commands.runCommand;
 import static org.graalvm.tests.integration.utils.Commands.stopAllRunningContainers;
 import static org.graalvm.tests.integration.utils.Commands.stopRunningContainer;
+import static org.graalvm.tests.integration.utils.Commands.waitForContainerLogToMatch;
 import static org.graalvm.tests.integration.utils.Commands.waitForTcpClosed;
 
 /**
@@ -105,6 +107,10 @@ public class RuntimesSmokeTest {
             process = runCommand(cmd, appDir, processLog, app);
             Logs.appendln(report, appDir.getAbsolutePath());
             Logs.appendlnSection(report, String.join(" ", cmd));
+
+            if (app.runtimeContainer != ContainerNames.NONE) {
+                waitForContainerLogToMatch(app.runtimeContainer.name, Pattern.compile(".*started.*"), 5, 1, TimeUnit.SECONDS);
+            }
 
             // Test web pages
             final long timeToFirstOKRequest = WebpageTester.testWeb(app.urlContent.urlContent[0][0], 10, app.urlContent.urlContent[0][1], true);

--- a/testsuite/src/it/java/org/graalvm/tests/integration/RuntimesSmokeTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/RuntimesSmokeTest.java
@@ -109,7 +109,7 @@ public class RuntimesSmokeTest {
             Logs.appendlnSection(report, String.join(" ", cmd));
 
             if (app.runtimeContainer != ContainerNames.NONE) {
-                waitForContainerLogToMatch(app.runtimeContainer.name, Pattern.compile(".*started.*"), 5, 1, TimeUnit.SECONDS);
+                waitForContainerLogToMatch(app.runtimeContainer.name, Pattern.compile(".*started.*"), 3000, 500, TimeUnit.MILLISECONDS);
             }
 
             // Test web pages

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
@@ -67,6 +67,15 @@ public enum WhitelistLogLines {
                     Pattern.compile(".*time=.*level=warning.*msg=.*S.gpg-agent.*since it is a socket.*"),
                     // Testcontainers, depends on local setup. Not our test issue.
                     Pattern.compile(".*Please ignore if you don't have images in an authenticated registry.*"),
+                    // Common new Q versions
+                    Pattern.compile(".*io.quarkus.narayana.jta.runtime.graal.DisableLoggingFeature.*"),
+                    // Podman / Docker extension incompatibilities with Podman versions
+                    Pattern.compile(".*Database JDBC URL \\[undefined/unknown\\].*"),
+                    Pattern.compile(".*Database driver: undefined/unknown.*"),
+                    Pattern.compile(".*Autocommit mode: undefined/unknown.*"),
+                    Pattern.compile(".*Minimum pool size: undefined/unknown.*"),
+                    Pattern.compile(".*Isolation level: <unknown>.*"),
+                    Pattern.compile(".*Maximum pool size: undefined/unknown.*"),
             };
         }
     },
@@ -168,12 +177,14 @@ public enum WhitelistLogLines {
             p.add(Pattern.compile(".*Attempted to read Testcontainers configuration file.*"));
             p.add(Pattern.compile(".*does not support the reuse of containers.*"));
             // Ryuk can spit warning that is on its own line.
-            p.add(Pattern.compile("^\\[WARNING\\]$"));
+            p.add(Pattern.compile("^\\[WARNING\\][\\s\\t]*$"));
             // GC warning thrown in GraalVM >= 22.0 under constraint environment (e.g. CI)
             // see https://github.com/Karm/mandrel-integration-tests/issues/68
             p.add(Pattern.compile(".*GC warning: [0-9.]+s spent in [0-9]+ GCs during the last stage, taking up [0-9]+.[0-9]+% of the time.*"));
             // JUnit output
             p.add(Pattern.compile(".* Failures: 0, Errors: 0,.*"));
+            // Docker image extension being mean
+            p.add(Pattern.compile(".*Using executable podman within the quarkus-container-image-docker.*"));
             if (QUARKUS_VERSION.majorIs(3) || QUARKUS_VERSION.isSnapshot()) {
                 // Testcontainers
                 p.add(Pattern.compile(".*org.tes.uti.ResourceReaper.*"));

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
@@ -65,6 +65,8 @@ public enum WhitelistLogLines {
                     // Podman with cgroupv2 on RHEL 9 intermittently spits out this message to no apparent effect on our tests
                     Pattern.compile(".*level=error msg=\"Cannot get exit code: died not found: unable to find event\".*"),
                     Pattern.compile(".*time=.*level=warning.*msg=.*S.gpg-agent.*since it is a socket.*"),
+                    // Podman -> registry network/comm issue?
+                    Pattern.compile(".*time=.*level=warning.*msg=.*Failed, retrying in.*pull&service=quay\\.io.*: net/http: TLS handshake timeout.*"),
                     // Testcontainers, depends on local setup. Not our test issue.
                     Pattern.compile(".*Please ignore if you don't have images in an authenticated registry.*"),
                     // Common new Q versions


### PR DESCRIPTION
There is a combination of Podman version and Java version where this piece of code hangs indefinitely:

```java
final URLConnection c = new URL(url).openConnection();
c.setRequestProperty("Accept", "*/*");
c.setConnectTimeout(500);
try (Scanner scanner = new Scanner(c.getInputStream(), StandardCharsets.UTF_8)) {
                                    ^^^^^^^^^^^^^^^^^
   scanner.useDelimiter("\\A");
   webPage = scanner.hasNext() ? scanner.next() : "";
}
```

on Scanner trying to read the input stream.  It seems that what used to be rather simple:

    a) an exception is thrown, because Quarkus is not yet ready
    b) a request response is populated in the buffer and read

is now more convoluted with some third state 

    c) no exception is thrown, but the buffer is not populated, Scanner hangs

I included a check for word `started` in the container log and that seems to alleviate this situation.
