### PR TITLE
Tests graalvm-community-jdk21u-issues-28

### DIFF
--- a/apps/jdkreflections/pom.xml
+++ b/apps/jdkreflections/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>jdkreflections</groupId>
+    <artifactId>jdkreflections</artifactId>
+    <version>1</version>
+
+    <name>jdkreflections</name>
+
+    <parent>
+        <groupId>org.graalvm.tests.integration</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <properties>
+        <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
+    </properties>
+
+    <build>
+        <finalName>jdkreflections</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven-jar-plugin.version}</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>jdkreflections.Main</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/apps/jdkreflections/src/main/java/jdkreflections/Main.java
+++ b/apps/jdkreflections/src/main/java/jdkreflections/Main.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2024, Red Hat Inc. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package jdkreflections;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+public class Main {
+
+    /**
+     * An intentionally elaborate way to do this to test the reflection support
+     * on java.lang.Thread for native-image build configuration.
+     * @param name
+     * @return
+     */
+    static ExecutorService createVirtualThreadExecutor(String name) {
+        try {
+            final Method virtualThreadBuilderMethod = Arrays.stream(Thread.class.getMethods())
+                    .filter(m -> m.getName().equals("ofVirtual"))
+                    .findAny().orElseThrow();
+            Object virtualThreadBuilder = virtualThreadBuilderMethod.invoke(null);
+            final Method nameVirtualThreadBuilderMethod = Arrays.stream(virtualThreadBuilderMethod.getReturnType().getMethods())
+                    .filter(m -> m.getName().equals("name") && m.getParameterCount() == 2)
+                    .findAny().orElseThrow();
+            virtualThreadBuilder = nameVirtualThreadBuilderMethod.invoke(virtualThreadBuilder, name, 10000L);
+            final Method factoryVirtualThreadBuilderMethod = Arrays.stream(Class.forName("java.lang.Thread$Builder").getMethods())
+                    .filter(m -> m.getName().equals("factory"))
+                    .findAny().orElseThrow();
+            final ThreadFactory factory = (ThreadFactory) factoryVirtualThreadBuilderMethod.invoke(virtualThreadBuilder);
+            final Method newThreadPerTaskExecutorMethod = Arrays.stream(Executors.class.getMethods())
+                    .filter(m -> m.getName().equals("newThreadPerTaskExecutor") && m.getGenericParameterTypes()[0].equals(ThreadFactory.class))
+                    .findAny().orElseThrow();
+            return (ExecutorService) newThreadPerTaskExecutorMethod.invoke(null, factory);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Fail :-)", e);
+        }
+    }
+
+    public static void main(String[] args) throws InterruptedException {
+        final ExecutorService executor = createVirtualThreadExecutor("meh-");
+        executor.submit(() -> {
+            try {
+                final Method currentThreadMethod = Thread.class.getDeclaredMethod("currentThread");
+                final Thread currentThread = (Thread) currentThreadMethod.invoke(null);
+                final Method isVirtualMethod = Thread.class.getDeclaredMethod("isVirtual");
+                final boolean isVirtual = (boolean) isVirtualMethod.invoke(currentThread);
+                System.out.println("Hello from a " + (isVirtual ? "virtual" : "") + " thread called " + currentThread.getName());
+                final Field interruptedField = Thread.class.getDeclaredField("interrupted");
+                interruptedField.setAccessible(true);
+                System.out.println("interrupted: " + interruptedField.getBoolean(currentThread));
+                final Method holdsLockMethod = Arrays.stream(Thread.class.getMethods())
+                        .filter(m -> m.getName().equals("holdsLock") && m.getGenericParameterTypes()[0].equals(Object.class))
+                        .findAny().orElseThrow();
+                System.out.println("holdsLock: " + ((boolean) holdsLockMethod.invoke(null, new Object())));
+                final Method threadIdMethod = Thread.class.getDeclaredMethod("threadId");
+                System.out.println("getId: " + ((long) threadIdMethod.invoke(currentThread)));
+                final Method getNextThreadIdOffsetMethod = Thread.class.getDeclaredMethod("getNextThreadIdOffset");
+                getNextThreadIdOffsetMethod.setAccessible(true);
+                System.out.println("getNextThreadIdOffset: " + (long) getNextThreadIdOffsetMethod.invoke(null));
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+        executor.shutdown();
+        executor.awaitTermination(1, java.util.concurrent.TimeUnit.SECONDS);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
                 <module>apps/debug-symbols-smoke</module>
                 <module>apps/helidon-quickstart-se</module>
                 <module>apps/imageio</module>
+                <module>apps/jdkreflections</module>
                 <module>apps/jfr-native-image-performance</module>
                 <module>apps/quarkus-full-microprofile</module>
                 <module>apps/quarkus-json</module>

--- a/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
@@ -860,13 +860,13 @@ public class AppReproducersTest {
 
     @Test
     @Tag("builder-image")
-    @IfMandrelVersion(minJDK = "21.0.3", inContainer = true)
+    @IfMandrelVersion(minJDK = "21.0.0", inContainer = true)
     public void jdkReflectionsContainerTest(TestInfo testInfo) throws IOException, InterruptedException {
         jdkReflections(testInfo, Apps.JDK_REFLECTIONS_BUILDER_IMAGE);
     }
 
     @Test
-    @IfMandrelVersion(minJDK = "21.0.3")
+    @IfMandrelVersion(minJDK = "21.0.0")
     public void jdkReflectionsTest(TestInfo testInfo) throws IOException, InterruptedException {
         jdkReflections(testInfo, Apps.JDK_REFLECTIONS);
     }

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/Apps.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/Apps.java
@@ -203,7 +203,17 @@ public enum Apps {
             URLContent.NONE,
             WhitelistLogLines.FOR_SERIALIZATION,
             BuildAndRunCmds.FOR_SERIALIZATION_BUILDER_IMAGE,
-            ContainerNames.FOR_SERIALIZATION_BUILDER_IMAGE);
+            ContainerNames.FOR_SERIALIZATION_BUILDER_IMAGE),
+    JDK_REFLECTIONS("apps" + File.separator + "jdkreflections",
+            URLContent.NONE,
+            WhitelistLogLines.JDK_REFLECTIONS,
+            BuildAndRunCmds.JDK_REFLECTIONS,
+            ContainerNames.NONE),
+    JDK_REFLECTIONS_BUILDER_IMAGE("apps" + File.separator + "jdkreflections",
+            URLContent.NONE,
+            WhitelistLogLines.JDK_REFLECTIONS,
+            BuildAndRunCmds.JDK_REFLECTIONS_BUILDER_IMAGE,
+            ContainerNames.JDK_REFLECTIONS_BUILDER_IMAGE);
 
     public final String dir;
     public final URLContent urlContent;

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildAndRunCmds.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildAndRunCmds.java
@@ -226,6 +226,32 @@ public enum BuildAndRunCmds {
             new String[][] {
                     { IS_THIS_WINDOWS ? "target\\timezones.exe" : "./target/timezones" } }
     ),
+    JDK_REFLECTIONS(
+            new String[][] {
+                    { "mvn", "package" },
+                    { "java", "--add-opens=java.base/java.lang=ALL-UNNAMED", "-agentlib:native-image-agent=config-output-dir=./target/AGENT",
+                            "-cp", "target/jdkreflections.jar", "jdkreflections.Main" },
+                    { "native-image", "-J--add-opens=java.base/java.lang=ALL-UNNAMED", "-H:ConfigurationFileDirectories=./target/AGENT",
+                            "--link-at-build-time=", "--no-fallback", "-march=native", "-jar", "target/jdkreflections.jar", "target/jdkreflections" }
+            },
+            new String[][] {
+                    { IS_THIS_WINDOWS ? "target\\jdkreflections.exe" : "./target/jdkreflections" } }
+    ),
+    JDK_REFLECTIONS_BUILDER_IMAGE(
+            new String[][] {
+                    { "mvn", "package" },
+                    { CONTAINER_RUNTIME, "run", IS_THIS_WINDOWS ? "" : "-u", IS_THIS_WINDOWS ? "" : getUnixUIDGID(),
+                            "-t", "--entrypoint", "java",  "-v", BASE_DIR + File.separator + "apps" + File.separator + "jdkreflections:/project:z",
+                            BUILDER_IMAGE, "--add-opens=java.base/java.lang=ALL-UNNAMED",
+                            "-agentlib:native-image-agent=config-output-dir=./target/AGENT", "-cp", "target/jdkreflections.jar", "jdkreflections.Main" },
+                    { CONTAINER_RUNTIME, "run", IS_THIS_WINDOWS ? "" : "-u", IS_THIS_WINDOWS ? "" : getUnixUIDGID(),
+                            "-v", BASE_DIR + File.separator + "apps" + File.separator + "jdkreflections:/project:z",
+                            BUILDER_IMAGE, "-J--add-opens=java.base/java.lang=ALL-UNNAMED",
+                            "-H:ConfigurationFileDirectories=./target/AGENT", "--link-at-build-time=", "--no-fallback", "-march=native",
+                            "-jar", "target/jdkreflections.jar", "target/jdkreflections" } },
+            new String[][] {
+                    { IS_THIS_WINDOWS ? "target\\jdkreflections.exe" : "./target/jdkreflections" } }
+    ),
     CALENDARS(
             new String[][] {
                     { "mvn", "package" },
@@ -525,7 +551,7 @@ public enum BuildAndRunCmds {
         }
     }
 
-    final String[][] buildCommands;
+    public final String[][] buildCommands;
     public final String[][] runCommands;
 
     BuildAndRunCmds(String[][] buildCommands, String[][] runCommands)

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/Commands.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/Commands.java
@@ -293,7 +293,7 @@ public class Commands {
         if (logFile != null) {
             final String c = "Command: " + String.join(" ", command) + "\n";
             LOGGER.infof("Command: %s", command);
-            Files.write(logFile.toPath(), c.getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+            Files.write(logFile.toPath(), c.getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND, StandardOpenOption.CREATE);
             processBuilder.redirectOutput(ProcessBuilder.Redirect.appendTo(logFile));
         }
         if (input != null) {

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/ContainerNames.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/ContainerNames.java
@@ -34,6 +34,7 @@ public enum ContainerNames {
     HYPERFOIL("hyperfoil-container"),
     MONITOR_OFFSET_BUILDER_IMAGE("my-monitor-offset-runner"),
     FOR_SERIALIZATION_BUILDER_IMAGE("my-for-serialization-runner"),
+    JDK_REFLECTIONS_BUILDER_IMAGE("my-jdkreflections-runner"),
     NONE("NO_CONTAINER");
 
     public final String name;

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
@@ -366,8 +366,7 @@ public enum WhitelistLogLines {
     JDK_REFLECTIONS {
         @Override
         public Pattern[] get(boolean inContainer) {
-            return new Pattern[]{
-            };
+            return new Pattern[]{};
         }
     };
 

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
@@ -362,6 +362,13 @@ public enum WhitelistLogLines {
                     Pattern.compile(".*sun.reflect.ReflectionFactory is internal proprietary API.*")
             };
         }
+    },
+    JDK_REFLECTIONS {
+        @Override
+        public Pattern[] get(boolean inContainer) {
+            return new Pattern[]{
+            };
+        }
     };
 
     public abstract Pattern[] get(boolean inContainer);


### PR DESCRIPTION
Embeds a variation on the reproducer @zakkak outlined on the original issue.
This forces the native agent to register e.g. the `getNextThreadIdOffset` that later causes 
```
/bin/ld: jdkreflections.o:(.data+0x7b8): undefined reference to `Java_java_lang_Thread_getNextThreadIdOffset'
```

Fails with current Mandrel for JDK 21, passes with e.g. Mandrel for JDK 23.

```
 mvn clean verify -Dquarkus.version=3.15.1 -Ptestsuite -Dtest=AppReproducersTest#jdkReflectionsTest
```

or in a container:

```
mvn clean verify -Ptestsuite-builder-image 
    -Dtest=AppReproducersTest#jdkReflectionsContainerTest -Dquarkus.version=3.15.1
    -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-23
    -Dquarkus.native.container-runtime=podman
    -Drootless.container-runtime=true -Dpodman.with.sudo=false | tee log.log
```
...swap jdk-23 with jdk-21 to see the fail.