### PR TITLE
Increase timeout for `info functions .*smoke.*` gdb command

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
@@ -860,13 +860,13 @@ public class AppReproducersTest {
 
     @Test
     @Tag("builder-image")
-    @IfMandrelVersion(minJDK = "21.0.0", inContainer = true)
+    @IfMandrelVersion(min = "23.1.6", inContainer = true)
     public void jdkReflectionsContainerTest(TestInfo testInfo) throws IOException, InterruptedException {
         jdkReflections(testInfo, Apps.JDK_REFLECTIONS_BUILDER_IMAGE);
     }
 
     @Test
-    @IfMandrelVersion(minJDK = "21.0.0")
+    @IfMandrelVersion(min = "23.1.6")
     public void jdkReflectionsTest(TestInfo testInfo) throws IOException, InterruptedException {
         jdkReflections(testInfo, Apps.JDK_REFLECTIONS);
     }

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/GDBSession.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/GDBSession.java
@@ -59,7 +59,8 @@ public enum GDBSession {
                                                 "void debug_symbols_smoke.Main::lambda\\$thisIsTheEnd\\$0\\(java.io.ByteArrayOutputStream \\*, debug_symbols_smoke.ClassA \\*\\).*" +
                                                 "void debug_symbols_smoke.Main::main\\(java.lang.String\\[\\] \\*\\).*" +
                                                 "void debug_symbols_smoke.Main::thisIsTheEnd\\(java.util.List \\*\\).*"
-                                        , Pattern.DOTALL)),
+                                        , Pattern.DOTALL),
+                                15000), // Increase timeout to work around https://github.com/oracle/graal/issues/10512
                         new CP("break Main.java:70\n",
                                 Pattern.compile(".*Breakpoint 1 at .*: file debug_symbols_smoke/Main.java, line 70.*",
                                         Pattern.DOTALL)),


### PR DESCRIPTION
GDB appears to take longer to load symbols in `graal/master` builds than
it used to in 24.1.1.

24.1.1
```
gdb -q target/debug-symbols-smoke < gdb.commands  2.27s user 0.06s system 101% cpu 2.288 total
```

`graalm/master`
```
gdb -q target/debug-symbols-smoke < gdb.commands  3.01s user 0.05s system 102% cpu 2.995 total
```
