### PR TITLE
Allow list log line for jdkReflection test on Windows

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
@@ -387,7 +387,14 @@ public enum WhitelistLogLines {
     JDK_REFLECTIONS {
         @Override
         public Pattern[] get(boolean inContainer) {
-            return new Pattern[]{};
+            if ((UsedVersion.getVersion(inContainer).compareTo(Version.create(25, 0, 0)) >= 0) && IS_THIS_WINDOWS) {
+                return new Pattern[] {
+                        // See https://github.com/Karm/mandrel-integration-tests/issues/314
+                        Pattern.compile(".*Warning: Observed unexpected JNI call to GetStaticMethodID.*"),
+                };
+            } else {
+                return new Pattern[]{};
+            }
         }
     };
 


### PR DESCRIPTION
We did allow list certain log lines in #316. This wasn't sufficient since that only allowed those log lines for the `forSerialization` test, but not for the `jdkReflections` test. This fixes it.

From CI:
```
 2025-04-01 01:26:19.707 INFO  [o.g.t.i.u.Logs] (checkLog) build-and-run.log log for forSerializationPost24_2Test contains whitelisted error: `com.oracle.svm.configure.trace.AccessAdvisor: Warning: Observed unexpected JNI call to GetStaticMethodID (map(size=7, {(tracer,jni),(function,GetStaticMethodID),(class,java.lang.Boolean),(declaring_class,java.lang.Boolean),(caller_class,jdk.internal.loader.NativeLibraries$NativeLibraryImpl),(result,true),(args,[getBoolean, (Ljava/lang/String;)Z])})). Tracing all subsequent JNI accesses.'
```

OK. But then we get:
```
 Error:  jdkReflectionsTest{TestInfo}  Time elapsed: 67.789 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: 
build.log log should not contain error or warning lines that are not whitelisted. See D:\a\mandrel\mandrel\testsuite\target\archived-logs\org.graalvm.tests.integration.AppReproducersTest\jdkReflectionsTest\build.log and check these offending lines: 
com.oracle.svm.configure.trace.AccessAdvisor: Warning: Observed unexpected JNI call to GetStaticMethodID (map(size=7, {(tracer,jni),(function,GetStaticMethodID),(class,java.lang.Boolean),(declaring_class,java.lang.Boolean),(caller_class,jdk.internal.loader.NativeLibraries$NativeLibraryImpl),(result,true),(args,[getBoolean, (Ljava/lang/String;)Z])})). Tracing all subsequent JNI accesses. ==> expected: <true> but was: <false>
	at org.graalvm.tests.integration.AppReproducersTest.jdkReflections(AppReproducersTest.java:902)
	at org.graalvm.tests.integration.AppReproducersTest.jdkReflectionsTest(AppReproducersTest.java:871)
```

... and indeed, the `build.log` file for `jdkReflectionsTest` has this:

```
[...]
cmd /C java --add-opens=java.base/java.lang=ALL-UNNAMED -agentlib:native-image-agent=config-output-dir=./target/AGENT -cp target/jdkreflections.jar jdkreflections.Main
Command: cmd /C java --add-opens=java.base/java.lang=ALL-UNNAMED -agentlib:native-image-agent=config-output-dir=./target/AGENT -cp target/jdkreflections.jar jdkreflections.Main
com.oracle.svm.configure.trace.AccessAdvisor: Warning: Observed unexpected JNI call to GetStaticMethodID (map(size=7, {(tracer,jni),(function,GetStaticMethodID),(class,java.lang.Boolean),(declaring_class,java.lang.Boolean),(caller_class,jdk.internal.loader.NativeLibraries$NativeLibraryImpl),(result,true),(args,[getBoolean, (Ljava/lang/String;)Z])})). Tracing all subsequent JNI accesses.
Hello from a virtual thread called meh-10000
interrupted: false
holdsLock: false
getId: 25
getNextThreadIdOffset: 140721858118672
cmd /C native-image -J--add-opens=java.base/java.lang=ALL-UNNAMED -H:ConfigurationFileDirectories=./target/AGENT --link-at-build-time= --no-fallback -march=native -jar target/jdkreflections.jar target/jdkreflections
Command: cmd /C native-image -J--add-opens=java.base/java.lang=ALL-UNNAMED -H:ConfigurationFileDirectories=./target/AGENT --link-at-build-time= --no-fallback -march=native -jar target/jdkreflections.jar target/jdkreflections
========================================================================================================================
GraalVM Native Image: Generating 'jdkreflections.exe' (executable)...
========================================================================================================================
[...]
```

Related: #314, #316