### PR TITLE
Minor JFR fix for obtaining image size

### DIFF
--- a/apps/jfr-native-image-performance/src/main/java/org/acme/getting/started/GreetingService.java
+++ b/apps/jfr-native-image-performance/src/main/java/org/acme/getting/started/GreetingService.java
@@ -28,7 +28,7 @@ public class GreetingService {
             try {
                 result = getNextString(text);
             } catch (Exception e) {
-                // Doesn't matter. Do nothing
+                throw new RuntimeException(e);
             }
         }
 

--- a/testsuite/src/it/java/org/graalvm/tests/integration/JFRTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/JFRTest.java
@@ -270,9 +270,9 @@ public class JFRTest {
                                              boolean inContainer) throws IOException, InterruptedException {
 
         final Map<String, Integer> measurementsJfr = runBenchmarkForApp(endpoint, 5, appJfr, appDir, processLog,
-                cn, mn, report, measurementsLog, inContainer, inContainer ? ContainerNames.JFR_PERFORMANCE_BUILDER_IMAGE.name : "jfr-perf-runner");
+                cn, mn, report, measurementsLog, inContainer, "jfr-perf-runner");
         final Map<String, Integer> measurementsNoJfr = runBenchmarkForApp(endpoint, 5, appNoJfr, appDir, processLog,
-                cn, mn, report, measurementsLog, inContainer, inContainer ? ContainerNames.JFR_PLAINTEXT_BUILDER_IMAGE.name : "jfr-plaintext-runner");
+                cn, mn, report, measurementsLog, inContainer,  "jfr-plaintext-runner");
 
         LOGGER.info("JFR measurementsJfr records: " + measurementsJfr.size() + ", measurementsNoJfr records: " + measurementsNoJfr.size());
         long imageSizeDiff = getMeasurementDiff("imageSize", measurementsJfr, measurementsNoJfr);

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildAndRunCmds.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/BuildAndRunCmds.java
@@ -344,7 +344,7 @@ public enum BuildAndRunCmds {
     ),
     JFR_PERFORMANCE_BUILDER_IMAGE(
             new String[][] {
-                    { "mvn", "--batch-mode", "clean", "package", "-Pnative", "-Dquarkus.native.container-build=true",
+                    { "mvn", "--batch-mode", "package", "-Pnative", "-Dquarkus.native.container-build=true",
                             "-Dquarkus.native.container-runtime=" + CONTAINER_RUNTIME,
                             "-Dquarkus.native.builder-image=" + BUILDER_IMAGE, "-Dquarkus.version=" + QUARKUS_VERSION.getVersionString(), "-Dquarkus.native.monitoring=jfr",
                             "-Dquarkus.native.additional-build-args=-H:+SignalHandlerBasedExecutionSampler",
@@ -363,7 +363,7 @@ public enum BuildAndRunCmds {
     ),
     PLAINTEXT_PERFORMANCE_BUILDER_IMAGE(
             new String[][] {
-                    { "mvn", "--batch-mode", "clean", "package", "-Pnative", "-Dquarkus.native.container-build=true",
+                    { "mvn", "--batch-mode", "package", "-Pnative", "-Dquarkus.native.container-build=true",
                             "-Dquarkus.native.container-runtime=" + CONTAINER_RUNTIME,
                             "-Dquarkus.native.builder-image=" + BUILDER_IMAGE, "-Dquarkus.version=" + QUARKUS_VERSION.getVersionString(),
                             "-DfinalName=jfr-plaintext" },


### PR DESCRIPTION
This is just a small fix to correct the way the binary size is obtained.  Previously, we were getting the size of the first file in the directory that ended in _"-runner"_. This resulted in obtaining the size of the same file twice. 

I've also changed the JFR configuration to be based on profile.jfc. This should cause JFR to work a little bit harder. 