### PR TITLE
Fix StaticDistroChecksTest for GraalVM CE builds

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/StaticDistroChecksTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/StaticDistroChecksTest.java
@@ -77,11 +77,11 @@ public class StaticDistroChecksTest {
             assertTrue(Files.exists(graalHomeSpaceBin.toPath()), graalHomeSpaceBin + " does not exist");
             final String result = runCommand(IS_THIS_WINDOWS ?
                             List.of("cmd", "/C", "native-image", "--version") :
-                            List.of("bash", "native-image", "--version")
+                            List.of("native-image", "--version")
                     , graalHomeSpaceBin,
                     Map.of("GRAALVM_HOME", graalHomeSpace.toString(),
                             "PATH", graalHomeSpaceBin.getAbsolutePath() + File.pathSeparator + System.getenv("PATH")));
-            final Pattern p = Pattern.compile("(?:GraalVM|native-image).*(?:Java Version|OpenJDK Runtime).*", Pattern.DOTALL);
+            final Pattern p = Pattern.compile("(?:GraalVM|native-image).*(?:Java Version|OpenJDK Runtime|GraalVM Runtime).*", Pattern.DOTALL);
             assertTrue(p.matcher(result).matches(), "Correct --version output expected. Got: `" + result + "', " +
                     "possibly https://github.com/oracle/graal/pull/4635");
         } finally {


### PR DESCRIPTION
I propose to call `native-image --version` directly. Not go the `bash native-image --version` indirection. Not sure if that will break anything. It works for my testing. Thoughts, @Karm?

Closes: #332 