### PR TITLE
Allow list maven 3.9.10 warnings with JDK 25

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/Apps.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/Apps.java
@@ -211,12 +211,12 @@ public enum Apps {
             ContainerNames.JDK_REFLECTIONS_BUILDER_IMAGE),
     VTHREADS_PROPS("apps" + File.separator + "vthread_props",
             URLContent.NONE,
-            WhitelistLogLines.NONE,
+            WhitelistLogLines.VTHREADS,
             BuildAndRunCmds.VTHREADS_PROPS,
             ContainerNames.NONE),
     VTHREADS_PROPS_BUILDER_IMAGE("apps" + File.separator + "vthread_props",
             URLContent.NONE,
-            WhitelistLogLines.NONE,
+            WhitelistLogLines.VTHREADS,
             BuildAndRunCmds.VTHREADS_PROPS_BUILDER_IMAGE,
             ContainerNames.VTHREADS_PROPS_BUILDER_IMAGE);
 

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
@@ -468,6 +468,18 @@ public enum WhitelistLogLines {
                 return new Pattern[] {};
             }
         }
+    },
+    VTHREADS {
+        @Override
+        public Pattern[] get(boolean inContainer) {
+            return new Pattern[] {
+                    // Maven 3.9.10 has a dependency - guice - which uses sun.misc.Unsafe::staticFieldBase
+                    // and produces a warning on JDK 25+. See https://github.com/Karm/mandrel-integration-tests/issues/341
+                    Pattern.compile(".*WARNING:.*sun.misc.Unsafe::staticFieldBase has been called by com\\.google\\.inject\\.internal\\.aop\\.HiddenClassDefiner.*"),
+                    Pattern.compile(".*WARNING:.*Please consider reporting this to the maintainers of class com\\.google\\.inject\\.internal\\.aop\\.HiddenClassDefiner.*"),
+                    Pattern.compile(".*WARNING:.*sun\\.misc\\.Unsafe::staticFieldBase will be removed in a future release.*")
+            };
+        }
     };
 
     public abstract Pattern[] get(boolean inContainer);


### PR DESCRIPTION
Allow maven 3.9.10 warnings that we cannot influence.

Closes: #341