### PR TITLE
Increase timeout for backtrace command in debugSymbolsQuarkus

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/GDBSession.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/GDBSession.java
@@ -249,7 +249,7 @@ public enum GDBSession {
                     new CP("GOTO URL http://localhost:8080/data/config/lookup",
                             Pattern.compile(".*lookup value.*", Pattern.DOTALL)),
                     new CP("bt\n",
-                            Pattern.compile(".*at.*com/example/quarkus/config/ConfigTestController.java:33.*", Pattern.DOTALL)),
+                            Pattern.compile(".*at.*com/example/quarkus/config/ConfigTestController.java:33.*", Pattern.DOTALL), increasedTimeoutMs),
                     new CP("list\n",
                             Pattern.compile(".*String value = config.getValue\\(\"value\", String.class\\);.*", Pattern.DOTALL)),
                     new CP("c&\n",


### PR DESCRIPTION
Using the existing `increasedTimeoutMS` which is set to 80000ms.  This might be appear as too high, but we already use it for other commands taking 10-15 secs, like the first breakpoint command, as we have seen some pretty slow VMs hitting the timeout if it's not high enough.

Reusing an existing value also keeps things simpler.

Closes https://github.com/Karm/mandrel-integration-tests/issues/360