### PR TITLE
Added Perf errors to the QUARKUS_FULL_MICROPROFILE's log whitelist

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
@@ -228,6 +228,13 @@ public enum WhitelistLogLines {
             p.add(Pattern.compile(".*Failed to register an accepted channel:.*"));
             // Hyperfoil warning message, because there are sometimes too many requests. Shouldn't influence the app's GC times too much.
             p.add(Pattern.compile(".*Pool depleted, throttling execution! Enable trace logging to see subsequent pool depletion messages\\..*"));
+            // Perf error likely due to missing Kernel support for CPU's 'topdown-retiring' Performance Monitoring Unit.
+            // Not likely to be Mandrel related.
+            // Similar issues:
+            // https://github.com/microsoft/WSL/issues/8480
+            // https://stackoverflow.com/questions/75680105/why-dose-perf-stat-a-topdown-not-support-on-my-system
+            p.add(Pattern.compile(".*event syntax error: 'topdown-retiring/metric-id=topdown!1retiring/,TOPDOWN\\.SL\\.\\.'.*"));
+            p.add(Pattern.compile(".*Initial error:.*"));
             return p.toArray(new Pattern[0]);
         }
     },


### PR DESCRIPTION
I Added two Perf errors, which were seen in the CI, to the QUARKUS_FULL_MICROPROFILE's log whitelist.

Fixes #372.