### PR TITLE
Pass QUARKUS_NATIVE_ADDITIONAL_BUILD_ARGS_APPEND env to quarkus apps

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/DebugSymbolsTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/DebugSymbolsTest.java
@@ -73,6 +73,7 @@ import static org.graalvm.tests.integration.utils.Commands.cleanup;
 import static org.graalvm.tests.integration.utils.Commands.getBaseDir;
 import static org.graalvm.tests.integration.utils.Commands.getRunCommand;
 import static org.graalvm.tests.integration.utils.Commands.processStopper;
+import static org.graalvm.tests.integration.utils.Commands.quarkusEnv;
 import static org.graalvm.tests.integration.utils.Commands.removeContainers;
 import static org.graalvm.tests.integration.utils.Commands.runCommand;
 import static org.graalvm.tests.integration.utils.Commands.stopAllRunningContainers;
@@ -231,7 +232,8 @@ public class DebugSymbolsTest {
             } else {
                 switches = null;
             }
-            builderRoutine(app, report, cn, mn, appDir, processLog, null, switches);
+            Map<String, String> environment = quarkusEnv();
+            builderRoutine(app, report, cn, mn, appDir, processLog, environment, switches);
 
             assertTrue(Files.exists(Path.of(appDir.getAbsolutePath(), "target", "quarkus-runner")),
                     "Quarkus executable does not exist. Compilation failed. Check the logs.");

--- a/testsuite/src/it/java/org/graalvm/tests/integration/JFRTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/JFRTest.java
@@ -85,6 +85,7 @@ import static org.graalvm.tests.integration.utils.Commands.getUnixUIDGID;
 import static org.graalvm.tests.integration.utils.Commands.openSSHTunnel;
 import static org.graalvm.tests.integration.utils.Commands.pidKiller;
 import static org.graalvm.tests.integration.utils.Commands.processStopper;
+import static org.graalvm.tests.integration.utils.Commands.quarkusEnv;
 import static org.graalvm.tests.integration.utils.Commands.removeContainers;
 import static org.graalvm.tests.integration.utils.Commands.replaceSwitchesInCmd;
 import static org.graalvm.tests.integration.utils.Commands.runCommand;
@@ -224,8 +225,9 @@ public class JFRTest {
             }
 
             // Container build requires an additional step: docker build...
-            builderRoutine(appJfr, report, cn, mn, appDir, processLog, null, switches);
-            builderRoutine(appNoJfr, report, cn, mn, appDir, processLog, null, switches);
+            Map<String, String> environment = quarkusEnv();
+            builderRoutine(appJfr, report, cn, mn, appDir, processLog, environment, switches);
+            builderRoutine(appNoJfr, report, cn, mn, appDir, processLog, environment, switches);
 
             startComparisonForBenchmark(Endpoint.REGULAR, true, processLog, cn, mn, report, measurementsLog, appDir, appJfr, appNoJfr, inContainer);
             LOGGER.info("REGULAR workload completed.");

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/Commands.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/Commands.java
@@ -98,6 +98,7 @@ public class Commands {
     private static final Pattern NUM_PATTERN = Pattern.compile("[ \t]*[0-9]+[ \t]*");
     private static final Pattern ALPHANUMERIC_FIRST = Pattern.compile("([a-z0-9]+).*");
     private static final Pattern CONTAINER_STATS_MEMORY = Pattern.compile("(?:table)?[ \t]*([0-9\\.]+)([a-zA-Z]+).*");
+    private static final String QUARKUS_ADDITIONAL_BUILD_ARGS_APPEND_ENV = "QUARKUS_NATIVE_ADDITIONAL_BUILD_ARGS_APPEND";
 
     public static final String GRAALVM_EXPERIMENTAL_BEGIN = "<GRAALVM_EXPERIMENTAL_BEGIN>";
     public static final String GRAALVM_EXPERIMENTAL_END = "<GRAALVM_EXPERIMENTAL_END>";
@@ -588,6 +589,15 @@ public class Commands {
             p.waitFor();
         }
         return count;
+    }
+
+    public static Map<String, String> quarkusEnv() {
+        String value = System.getenv(QUARKUS_ADDITIONAL_BUILD_ARGS_APPEND_ENV);
+        if (value != null) {
+            return Map.of(QUARKUS_ADDITIONAL_BUILD_ARGS_APPEND_ENV, value);
+        } else {
+            return null;
+        }
     }
 
     public static void processStopper(Process p, boolean force) throws InterruptedException {


### PR DESCRIPTION
While looking at the CI jobs at https://github.com/graalvm/mandrel/pull/918 which adds extra native image flags via the `QUARKUS_NATIVE_ADDITIONAL_BUILD_ARGS_APPEND` environment I've noticed that the Mandrel IT tests that use quarkus, don't have the parameters present when the native images are being built.

This patch changes it to pass that environment if it's present. Thoughts?