### PR TITLE
Add <extension>true</extension> to quarkus-maven-plugin for JFR perf app

### DIFF
--- a/apps/jfr-native-image-performance/pom.xml
+++ b/apps/jfr-native-image-performance/pom.xml
@@ -63,6 +63,7 @@
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <version>${quarkus.version}</version>
+                <extensions>true</extensions>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Tested with quarkus main branch.

## Before:
```
[INFO] --- quarkus:999-SNAPSHOT:build (default) @ jfr-native-image-performance ---
[WARNING] The Maven extensions for the Quarkus Maven plugin are not enabled for this build. We recommend enabling this, so that the plugin can verify essential build settings have been configured as required. Please enable by adding "<extensions>true</extensions>" in your quarkus-maven-plugin declaration; it should look like:

	<plugin>
		<groupId>${quarkus.platform.group-id}</groupId>
		<artifactId>quarkus-maven-plugin</artifactId>
		<version>${quarkus.platform.version}</version>
		<extensions>true</extensions> <!-- THIS ONE -->
		...
[WARNING] [io.quarkus.deployment.configuration] Configuration property 'quarkus.package.type' has been deprecated and replaced by: [quarkus.package.jar.enabled, quarkus.package.jar.type, quarkus.native.enabled, quarkus.native.sources-only]
```
## After:
```
[INFO] --- quarkus:999-SNAPSHOT:build (default) @ jfr-native-image-performance ---
[WARNING] [io.quarkus.deployment.configuration] Configuration property 'quarkus.package.type' has been deprecated and replaced by: [quarkus.package.jar.enabled, quarkus.package.jar.type, quarkus.native.enabled, quarkus.native.sources-only]
```

Closes #382 