### PR TITLE
Added three error lines into the whitelist

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
@@ -82,6 +82,11 @@ public enum WhitelistLogLines {
             p.add(Pattern.compile(".*Minimum pool size: undefined/unknown.*"));
             p.add(Pattern.compile(".*Isolation level: <unknown>.*"));
             p.add(Pattern.compile(".*Maximum pool size: undefined/unknown.*"));
+            if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.27.0")) >= 0) {
+                p.add(Pattern.compile(".*JDBC fetch size: undefined/unknown.*"));
+                p.add(Pattern.compile(".*Pool: undefined/unknown.*"));
+                p.add(Pattern.compile(".*Default catalog/schema: unknown/unknown.*"));
+            }
             if ((UsedVersion.getVersion(inContainer).compareTo(Version.create(24, 2, 0)) >= 0)) {
                 p.add(Pattern.compile(".*A terminally deprecated method in sun.misc.Unsafe has been called.*"));
                 p.add(Pattern.compile(".*java.lang.System::load has been called by org.fusesource.jansi.internal.JansiLoader in an unnamed module.*jansi-.*.jar.*"));


### PR DESCRIPTION
Hi,
On newer Quarkus versions, these three new error lines popped up, adding them into the whitelist would fix `testQuarkusMPOrmAwtContainer`.

@Karm, we discussed this on Slack yesterday when I tried running it locally, but the test also popped up in infra now with this failure.

What do you think?