### PR TITLE
Added a Podman warning and error into the whitelist

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
@@ -338,6 +338,8 @@ public enum WhitelistLogLines {
             }
             // harmless Podman noise, does not affect the test outcome (https://github.com/containers/podman/discussions/19920)
             p.add(Pattern.compile(".*time=\".*\" level=warning msg=\"archive: skipping.*"));
+            // sometimes showing up, probably caused by Jaeger not running
+            p.add(Pattern.compile(".*Failed to export spans. The request could not be executed. Full error message: Client is closed.*"));
             return p.toArray(new Pattern[0]);
         }
     },


### PR DESCRIPTION
Hi, I added two harmless Podman logs into the error whitelist. They shouldn't affect any test results.

Links to discussions about the logs:
https://github.com/containers/podman/discussions/19920
https://github.com/containers/podman/issues/16217