### PR TITLE
Adapt test for quarkus-smallrye-metrics removal

### DIFF
--- a/apps/quarkus-full-microprofile/quarkus_3.31.x.patch
+++ b/apps/quarkus-full-microprofile/quarkus_3.31.x.patch
@@ -1,0 +1,311 @@
+diff --git a/apps/quarkus-full-microprofile/pom.xml b/apps/quarkus-full-microprofile/pom.xml
+index ce7df81..a07c885 100644
+--- a/apps/quarkus-full-microprofile/pom.xml
++++ b/apps/quarkus-full-microprofile/pom.xml
+@@ -15,7 +15,7 @@
+ 
+     <properties>
+         <quarkus.version>${global.quarkus.version}</quarkus.version>
+-        <vertx.auth.jwt.version>4.0.3</vertx.auth.jwt.version>
++        <vertx.auth.jwt.version>4.5.7</vertx.auth.jwt.version>
+     </properties>
+ 
+     <dependencyManagement>
+@@ -37,7 +37,7 @@
+         </dependency>
+         <dependency>
+             <groupId>io.quarkus</groupId>
+-            <artifactId>quarkus-resteasy</artifactId>
++            <artifactId>quarkus-rest</artifactId>
+         </dependency>
+         <dependency>
+             <groupId>io.quarkus</groupId>
+@@ -47,10 +47,6 @@
+             <groupId>io.quarkus</groupId>
+             <artifactId>quarkus-smallrye-jwt</artifactId>
+         </dependency>
+-        <dependency>
+-            <groupId>io.quarkus</groupId>
+-            <artifactId>quarkus-smallrye-metrics</artifactId>
+-        </dependency>
+         <dependency>
+             <groupId>io.quarkus</groupId>
+             <artifactId>quarkus-smallrye-health</artifactId>
+@@ -61,7 +57,7 @@
+         </dependency>
+         <dependency>
+             <groupId>io.quarkus</groupId>
+-            <artifactId>quarkus-smallrye-opentracing</artifactId>
++            <artifactId>quarkus-opentelemetry</artifactId>
+         </dependency>
+         <dependency>
+             <groupId>io.quarkus</groupId>
+diff --git a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/HelloController.java b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/HelloController.java
+index 0694ce6..88d552c 100644
+--- a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/HelloController.java
++++ b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/HelloController.java
+@@ -1,8 +1,8 @@
+ package com.example.quarkus;
+ 
+-import javax.inject.Singleton;
+-import javax.ws.rs.GET;
+-import javax.ws.rs.Path;
++import jakarta.inject.Singleton;
++import jakarta.ws.rs.GET;
++import jakarta.ws.rs.Path;
+ 
+ @Path("/hello")
+ @Singleton
+diff --git a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/QuarkusRestApplication.java b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/QuarkusRestApplication.java
+index 068ba12..410a130 100644
+--- a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/QuarkusRestApplication.java
++++ b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/QuarkusRestApplication.java
+@@ -1,7 +1,7 @@
+ package com.example.quarkus;
+ 
+-import javax.ws.rs.ApplicationPath;
+-import javax.ws.rs.core.Application;
++import jakarta.ws.rs.ApplicationPath;
++import jakarta.ws.rs.core.Application;
+ 
+ @ApplicationPath("/data")
+ public class QuarkusRestApplication extends Application {
+diff --git a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/client/ClientController.java b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/client/ClientController.java
+index 0f593eb..7360fcc 100644
+--- a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/client/ClientController.java
++++ b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/client/ClientController.java
+@@ -2,11 +2,11 @@ package com.example.quarkus.client;
+ 
+ import org.eclipse.microprofile.rest.client.inject.RestClient;
+ 
+-import javax.enterprise.context.ApplicationScoped;
+-import javax.inject.Inject;
+-import javax.ws.rs.GET;
+-import javax.ws.rs.Path;
+-import javax.ws.rs.PathParam;
++import jakarta.enterprise.context.ApplicationScoped;
++import jakarta.inject.Inject;
++import jakarta.ws.rs.GET;
++import jakarta.ws.rs.Path;
++import jakarta.ws.rs.PathParam;
+ 
+ @Path("/client")
+ @ApplicationScoped
+diff --git a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/client/Service.java b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/client/Service.java
+index ac9a4a5..35bcb99 100644
+--- a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/client/Service.java
++++ b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/client/Service.java
+@@ -2,10 +2,10 @@ package com.example.quarkus.client;
+ 
+ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+ 
+-import javax.enterprise.context.ApplicationScoped;
+-import javax.ws.rs.GET;
+-import javax.ws.rs.Path;
+-import javax.ws.rs.PathParam;
++import jakarta.enterprise.context.ApplicationScoped;
++import jakarta.ws.rs.GET;
++import jakarta.ws.rs.Path;
++import jakarta.ws.rs.PathParam;
+ 
+ @RegisterRestClient
+ @ApplicationScoped
+diff --git a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/client/ServiceController.java b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/client/ServiceController.java
+index 24a228d..6ec43f9 100644
+--- a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/client/ServiceController.java
++++ b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/client/ServiceController.java
+@@ -1,8 +1,8 @@
+ package com.example.quarkus.client;
+ 
+-import javax.ws.rs.GET;
+-import javax.ws.rs.Path;
+-import javax.ws.rs.PathParam;
++import jakarta.ws.rs.GET;
++import jakarta.ws.rs.Path;
++import jakarta.ws.rs.PathParam;
+ 
+ @Path("/client/service")
+ public class ServiceController {
+diff --git a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/config/ConfigTestController.java b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/config/ConfigTestController.java
+index 8119c23..517fe6f 100644
+--- a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/config/ConfigTestController.java
++++ b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/config/ConfigTestController.java
+@@ -4,10 +4,10 @@ import org.eclipse.microprofile.config.Config;
+ import org.eclipse.microprofile.config.ConfigProvider;
+ import org.eclipse.microprofile.config.inject.ConfigProperty;
+ 
+-import javax.enterprise.context.RequestScoped;
+-import javax.inject.Inject;
+-import javax.ws.rs.GET;
+-import javax.ws.rs.Path;
++import jakarta.enterprise.context.RequestScoped;
++import jakarta.inject.Inject;
++import jakarta.ws.rs.GET;
++import jakarta.ws.rs.Path;
+ 
+ /**
+  * !!! DO NOT TOUCH THE SOURCE WITHOUT EDITING GDBSession.java !!!
+diff --git a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/health/ServiceLiveHealthCheck.java b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/health/ServiceLiveHealthCheck.java
+index fea754c..d1ad0a6 100644
+--- a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/health/ServiceLiveHealthCheck.java
++++ b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/health/ServiceLiveHealthCheck.java
+@@ -4,7 +4,7 @@ import org.eclipse.microprofile.health.HealthCheck;
+ import org.eclipse.microprofile.health.HealthCheckResponse;
+ import org.eclipse.microprofile.health.Liveness;
+ 
+-import javax.enterprise.context.ApplicationScoped;
++import jakarta.enterprise.context.ApplicationScoped;
+ 
+ @Liveness
+ @ApplicationScoped
+diff --git a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/health/ServiceReadyHealthCheck.java b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/health/ServiceReadyHealthCheck.java
+index 6bb6374..cd7ac7a 100644
+--- a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/health/ServiceReadyHealthCheck.java
++++ b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/health/ServiceReadyHealthCheck.java
+@@ -4,7 +4,7 @@ import org.eclipse.microprofile.health.HealthCheck;
+ import org.eclipse.microprofile.health.HealthCheckResponse;
+ import org.eclipse.microprofile.health.Readiness;
+ 
+-import javax.enterprise.context.ApplicationScoped;
++import jakarta.enterprise.context.ApplicationScoped;
+ 
+ @Readiness
+ @ApplicationScoped
+diff --git a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/metric/MetricController.java b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/metric/MetricController.java
+deleted file mode 100644
+index 1f4c2df..0000000
+--- a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/metric/MetricController.java
++++ /dev/null
+@@ -1,49 +0,0 @@
+-package com.example.quarkus.metric;
+-
+-import org.eclipse.microprofile.metrics.Counter;
+-import org.eclipse.microprofile.metrics.MetricUnits;
+-import org.eclipse.microprofile.metrics.annotation.Gauge;
+-import org.eclipse.microprofile.metrics.annotation.Metric;
+-import org.eclipse.microprofile.metrics.annotation.Timed;
+-
+-import javax.enterprise.context.ApplicationScoped;
+-import javax.inject.Inject;
+-import javax.ws.rs.GET;
+-import javax.ws.rs.Path;
+-import java.util.Random;
+-
+-@Path("/metric")
+-@ApplicationScoped
+-public class MetricController {
+-
+-    @Inject
+-    @Metric(name = "endpoint_counter")
+-    Counter counter;
+-
+-    @Path("timed")
+-    @Timed(name = "timed-request")
+-    @GET
+-    public String timedRequest() {
+-        // This is just for demo/test proposes!!!
+-        int wait = new Random().nextInt(1000);
+-        try {
+-            Thread.sleep(wait);
+-        } catch (InterruptedException e) {
+-            // Demo
+-            e.printStackTrace();
+-        }
+-        return "Request is used in statistics, check with the Metrics call.";
+-    }
+-
+-    @Path("increment")
+-    @GET
+-    public long doIncrement() {
+-        counter.inc();
+-        return counter.getCount();
+-    }
+-
+-    @Gauge(name = "counter_gauge", unit = MetricUnits.NONE)
+-    long getCustomerCount() {
+-        return counter.getCount();
+-    }
+-}
+diff --git a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/resilient/ResilienceController.java b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/resilient/ResilienceController.java
+index 04cf5fb..fc34f8e 100644
+--- a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/resilient/ResilienceController.java
++++ b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/resilient/ResilienceController.java
+@@ -3,9 +3,9 @@ package com.example.quarkus.resilient;
+ import org.eclipse.microprofile.faulttolerance.Fallback;
+ import org.eclipse.microprofile.faulttolerance.Timeout;
+ 
+-import javax.enterprise.context.ApplicationScoped;
+-import javax.ws.rs.GET;
+-import javax.ws.rs.Path;
++import jakarta.enterprise.context.ApplicationScoped;
++import jakarta.ws.rs.GET;
++import jakarta.ws.rs.Path;
+ 
+ @Path("/resilience")
+ @ApplicationScoped
+diff --git a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/secure/JWTResource.java b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/secure/JWTResource.java
+index 9393c53..4e45fb3 100644
+--- a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/secure/JWTResource.java
++++ b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/secure/JWTResource.java
+@@ -8,14 +8,14 @@ import io.vertx.ext.auth.jwt.JWTAuth;
+ import io.vertx.ext.auth.jwt.JWTAuthOptions;
+ import org.eclipse.microprofile.config.inject.ConfigProperty;
+ 
+-import javax.annotation.PostConstruct;
+-import javax.enterprise.context.ApplicationScoped;
+-import javax.ws.rs.GET;
+-import javax.ws.rs.Path;
+-import javax.ws.rs.WebApplicationException;
+-import javax.ws.rs.client.Client;
+-import javax.ws.rs.client.ClientBuilder;
+-import javax.ws.rs.core.Response;
++import jakarta.annotation.PostConstruct;
++import jakarta.enterprise.context.ApplicationScoped;
++import jakarta.ws.rs.GET;
++import jakarta.ws.rs.Path;
++import jakarta.ws.rs.WebApplicationException;
++import jakarta.ws.rs.client.Client;
++import jakarta.ws.rs.client.ClientBuilder;
++import jakarta.ws.rs.core.Response;
+ import java.io.InputStream;
+ import java.nio.charset.StandardCharsets;
+ import java.util.Objects;
+diff --git a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/secure/ProtectedResource.java b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/secure/ProtectedResource.java
+index 7ae6dd4..06e10e8 100644
+--- a/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/secure/ProtectedResource.java
++++ b/apps/quarkus-full-microprofile/src/main/java/com/example/quarkus/secure/ProtectedResource.java
+@@ -3,11 +3,11 @@ package com.example.quarkus.secure;
+ import org.eclipse.microprofile.jwt.Claim;
+ import org.eclipse.microprofile.jwt.ClaimValue;
+ 
+-import javax.annotation.security.RolesAllowed;
+-import javax.enterprise.context.RequestScoped;
+-import javax.inject.Inject;
+-import javax.ws.rs.GET;
+-import javax.ws.rs.Path;
++import jakarta.annotation.security.RolesAllowed;
++import jakarta.enterprise.context.RequestScoped;
++import jakarta.inject.Inject;
++import jakarta.ws.rs.GET;
++import jakarta.ws.rs.Path;
+ 
+ @Path("/protected")
+ @RequestScoped
+diff --git a/apps/quarkus-full-microprofile/src/main/resources/application.properties b/apps/quarkus-full-microprofile/src/main/resources/application.properties
+index 911e899..caa2d91 100644
+--- a/apps/quarkus-full-microprofile/src/main/resources/application.properties
++++ b/apps/quarkus-full-microprofile/src/main/resources/application.properties
+@@ -6,8 +6,9 @@ quarkus.ssl.native=true
+ mp.jwt.verify.publickey.location=META-INF/resources/publicKey.pem
+ mp.jwt.verify.issuer=https://server.example.com
+ quarkus.smallrye-jwt.enabled=true
+-quarkus.jaeger.service-name=Demo-Service-A
+-quarkus.jaeger.sampler-type=const
+-quarkus.jaeger.sampler-param=1
+-quarkus.jaeger.endpoint=http://localhost:14268/api/traces
++quarkus.otel.traces.exporter=cdi
++quarkus.otel.traces.sampler=parentbased_always_on
++quarkus.otel.service.name=Demo-Service-A
++quarkus.otel.exporter.otlp.endpoint=http://localhost:4317
++quarkus.otel.exporter.otlp.traces.endpoint=http://localhost:4317
+ quarkus.native.resources.includes=privateKey.pem

--- a/testsuite/src/it/java/org/graalvm/tests/integration/DebugSymbolsTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/DebugSymbolsTest.java
@@ -207,7 +207,9 @@ public class DebugSymbolsTest {
         final String cn = testInfo.getTestClass().get().getCanonicalName();
         final String mn = testInfo.getTestMethod().get().getName();
         String patch = null;
-        if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_9_0) >= 0) {
+        if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_31_0) >= 0) {
+            patch = "quarkus_3.31.x.patch";
+        } else if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_9_0) >= 0) {
             patch = "quarkus_3.9.x.patch";
         } else if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_8_0) >= 0) {
             patch = "quarkus_3.8.x.patch";

--- a/testsuite/src/it/java/org/graalvm/tests/integration/PerfCheckTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/PerfCheckTest.java
@@ -443,7 +443,9 @@ public class PerfCheckTest {
         final List<Map<String, String>> reports = new ArrayList<>(2);
 
         String patch = null;
-        if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_9_0) >= 0) {
+        if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_31_0) >= 0) {
+            patch = "quarkus_3.31.x.patch";
+        } else if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_9_0) >= 0) {
             patch = "quarkus_3.9.x.patch";
         } else if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_8_0) >= 0) {
             patch = "quarkus_3.8.x.patch";
@@ -584,7 +586,9 @@ public class PerfCheckTest {
 
         // apply patches, when necessary
         String patch = null;
-        if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_9_0) >= 0) {
+        if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_31_0) >= 0) {
+            patch = "quarkus_3.31.x.patch";
+        } else if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_9_0) >= 0) {
             patch = "quarkus_3.9.x.patch";
         } else if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_8_0) >= 0) {
             patch = "quarkus_3.8.x.patch";

--- a/testsuite/src/it/java/org/graalvm/tests/integration/RuntimesSmokeTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/RuntimesSmokeTest.java
@@ -118,6 +118,13 @@ public class RuntimesSmokeTest {
             final long timeToFirstOKRequest = WebpageTester.testWeb(app.urlContent.urlContent[0][0], 10, app.urlContent.urlContent[0][1], true);
             LOGGER.info("Testing web page content...");
             for (String[] urlContent : app.urlContent.urlContent) {
+                if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_31_0) >= 0) {
+                    // skip metrics testing removed with: https://github.com/quarkusio/quarkus/pull/49735
+                    if (urlContent[0].equals("http://localhost:8080/q/metrics") ||
+                        urlContent[0].equals("http://localhost:8080/data/metric/timed")) {
+                        continue;
+                    }
+                }
                 WebpageTester.testWeb(urlContent[0], 5, urlContent[1], false);
             }
 
@@ -195,7 +202,9 @@ public class RuntimesSmokeTest {
         }
 
         String patch = null;
-        if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_9_0) >= 0) {
+        if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_31_0) >= 0) {
+            patch = "quarkus_3.31.x.patch";
+        } else if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_9_0) >= 0) {
             patch = "quarkus_3.9.x.patch";
         } else if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_8_0) >= 0) {
             patch = "quarkus_3.8.x.patch";

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/QuarkusVersion.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/versions/QuarkusVersion.java
@@ -33,6 +33,7 @@ public class QuarkusVersion implements Comparable<QuarkusVersion> {
     public static final QuarkusVersion V_3_8_0 = new QuarkusVersion("3.8.0");
     public static final QuarkusVersion V_3_9_0 = new QuarkusVersion("3.9.0");
     public static final QuarkusVersion V_3_21_0 = new QuarkusVersion("3.21.0");
+    public static final QuarkusVersion V_3_31_0 = new QuarkusVersion("3.31.0");
 
     private final String version;
     private final int major;


### PR DESCRIPTION
No more smallrye-metrics. The MetricController is removed by the patch. Testing that endpoint skipped when doing URLContent checks.

Thoughts?

Closes: #391