### PR TITLE
Allow list container already terminated warning

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
@@ -482,6 +482,8 @@ public enum WhitelistLogLines {
             if (UsedVersion.getVersion(inContainer).compareTo(Version.create(25, 0, 0)) >= 0) {
                 p.add(Pattern.compile(".*The build process encountered 1 warning\\..*"));
             }
+            // On podman 5.7.0 F42 we sometimes get: level=error msg="forwarding signal 15 to container <id>: sending signal to container <id>: `/usr/bin/crun kill <id> 15` failed: signal: terminated"
+            p.add(Pattern.compile(".*level=error.*msg=\"forwarding signal 15 to container.*"));
             return p.toArray(new Pattern[0]);
         }
     },


### PR DESCRIPTION
When working on #390 I ran into failures like the following:

```
2025-12-17 13:50:20.902 INFO  [o.g.t.i.u.Commands] (removeContainer) Command: [sudo, podman, rm, NO_CONTAINER, --force]
2025-12-17 13:50:20.949 INFO  [o.g.t.i.u.Commands] (removeContainer) Command: [sudo, podman, rm, NO_CONTAINER, --force]
2025-12-17 13:50:21.033 INFO  [o.g.t.i.u.Commands] (enableTurbo) Command: [sudo, bash, -c, echo 0 > /sys/devices/system/cpu/intel_pstate/no_turbo], Output: 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 220.276 s <<< FAILURE! - in org.graalvm.tests.integration.JFRTest
[ERROR] jfrPerfTest{TestInfo}  Time elapsed: 219.638 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: 
build-and-run.log log should not contain error or warning lines that are not whitelisted. See /disk/graal/upstream-sources/mandrel-integration-tests/testsuite/target/archived-logs/org.graalvm.tests.integration.JFRTest/jfrPerfTest/build-and-run.log and check these offending 3 lines: 
time="2025-12-17T13:49:52+01:00" level=error msg="forwarding signal 15 to container 6831589c314a2ada65a6de547c9f0a0e654ccc6b8b249c79bb5f42c241a4d984: sending signal to container 6831589c314a2ada65a6de547c9f0a0e654ccc6b8b249c79bb5f42c241a4d984: `/usr/bin/crun kill 6831589c314a2ada65a6de547c9f0a0e654ccc6b8b249c79bb5f42c241a4d984 15` failed: signal: terminated"
time="2025-12-17T13:48:57+01:00" level=error msg="forwarding signal 15 to container 26c5098469cc47b9b557fa5d6bb199163d3c6bbae8f7f25c6f671fe2a45b3e5e: sending signal to container 26c5098469cc47b9b557fa5d6bb199163d3c6bbae8f7f25c6f671fe2a45b3e5e: `/usr/bin/crun kill 26c5098469cc47b9b557fa5d6bb199163d3c6bbae8f7f25c6f671fe2a45b3e5e 15` failed: signal: terminated"
time="2025-12-17T13:50:17+01:00" level=error msg="forwarding signal 15 to container e25648bc0700de1e3f80f59228aedada0ec05333e12720f109186c0e809bf4df: sending signal to container e25648bc0700de1e3f80f59228aedada0ec05333e12720f109186c0e809bf4df: `/usr/bin/crun kill e25648bc0700de1e3f80f59228aedada0ec05333e12720f109186c0e809bf4df 15` failed: signal: terminated" ==> expected: <true> but was: <false>
	at org.graalvm.tests.integration.JFRTest.jfrPerfTestRun(JFRTest.java:241)
	at org.graalvm.tests.integration.JFRTest.jfrPerfTest(JFRTest.java:187)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   JFRTest.jfrPerfTest:187->jfrPerfTestRun:241 build-and-run.log log should not contain error or warning lines that are not whitelisted. See /disk/graal/upstream-sources/mandrel-integration-tests/testsuite/target/archived-logs/org.graalvm.tests.integration.JFRTest/jfrPerfTest/build-and-run.log and check these offending 3 lines: 
time="2025-12-17T13:49:52+01:00" level=error msg="forwarding signal 15 to container 6831589c314a2ada65a6de547c9f0a0e654ccc6b8b249c79bb5f42c241a4d984: sending signal to container 6831589c314a2ada65a6de547c9f0a0e654ccc6b8b249c79bb5f42c241a4d984: `/usr/bin/crun kill 6831589c314a2ada65a6de547c9f0a0e654ccc6b8b249c79bb5f42c241a4d984 15` failed: signal: terminated"
time="2025-12-17T13:48:57+01:00" level=error msg="forwarding signal 15 to container 26c5098469cc47b9b557fa5d6bb199163d3c6bbae8f7f25c6f671fe2a45b3e5e: sending signal to container 26c5098469cc47b9b557fa5d6bb199163d3c6bbae8f7f25c6f671fe2a45b3e5e: `/usr/bin/crun kill 26c5098469cc47b9b557fa5d6bb199163d3c6bbae8f7f25c6f671fe2a45b3e5e 15` failed: signal: terminated"
time="2025-12-17T13:50:17+01:00" level=error msg="forwarding signal 15 to container e25648bc0700de1e3f80f59228aedada0ec05333e12720f109186c0e809bf4df: sending signal to container e25648bc0700de1e3f80f59228aedada0ec05333e12720f109186c0e809bf4df: `/usr/bin/crun kill e25648bc0700de1e3f80f59228aedada0ec05333e12720f109186c0e809bf4df 15` failed: signal: terminated" ==> expected: <true> but was: <false>
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Native image integration TS 1.0.0-SNAPSHOT:
[INFO] 
[INFO] Native image integration TS ........................ SUCCESS [  0.089 s]
[INFO] testsuite .......................................... FAILURE [03:42 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  03:42 min
[INFO] Finished at: 2025-12-17T13:50:21+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.22.2:test (default-test) on project testsuite: There are test failures.
[ERROR] 
[ERROR] Please refer to /disk/graal/upstream-sources/mandrel-integration-tests/testsuite/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :testsuite
```

Those are errors when trying to stop a container and it's already terminated (AFAIK). Thus those should be benign. I propose to allow-list them.