### PR TITLE
Skip monitor field offset test for graal/master (25.1)

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
@@ -803,7 +803,7 @@ public class AppReproducersTest {
     }
 
     @Test
-    @IfMandrelVersion(minJDK = "21.0.3")
+    @IfMandrelVersion(minJDK = "21.0.3", max = "25.0.999")
     public void monitorFieldOffsetTest(TestInfo testInfo) throws IOException, InterruptedException {
         monitorFieldOffsetOK(testInfo, Apps.MONITOR_OFFSET_OK);
         monitorFieldOffsetNOK(testInfo, Apps.MONITOR_OFFSET_NOK);


### PR DESCRIPTION
The test is not useful there as the limits have been updated and the test would not trigger the wanted build failure, thus not useful.

Closes: #402