### PR TITLE
Mandrel 25 compatibility changes

### DIFF
--- a/apps/quarkus-mp-orm-dbs-awt/quarkus_3.31.x.patch
+++ b/apps/quarkus-mp-orm-dbs-awt/quarkus_3.31.x.patch
@@ -43,6 +43,15 @@ index bb38d46..b3b2a5a 100644
          </dependency>
          <dependency>
              <groupId>io.quarkus</groupId>
+@@ -103,7 +103,7 @@
+         </dependency>
+         <dependency>
+             <groupId>io.quarkus</groupId>
+-            <artifactId>quarkus-smallrye-metrics</artifactId>
++            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+         </dependency>
+         <dependency>
+             <groupId>io.quarkus</groupId>
 @@ -115,7 +117,7 @@
          </dependency>
          <dependency>
@@ -279,24 +288,88 @@ index 56d2a07..252ce0f 100644
  @Path("/protected")
  @RequestScoped
 diff --git a/apps/quarkus-mp-orm-dbs-awt/src/main/java/quarkus/metric/MetricController.java b/apps/quarkus-mp-orm-dbs-awt/src/main/java/quarkus/metric/MetricController.java
-index 9c4d7de..fb7840c 100644
+index 9c4d7de..f06f8cc 100644
 --- a/apps/quarkus-mp-orm-dbs-awt/src/main/java/quarkus/metric/MetricController.java
 +++ b/apps/quarkus-mp-orm-dbs-awt/src/main/java/quarkus/metric/MetricController.java
-@@ -6,10 +6,10 @@ import org.eclipse.microprofile.metrics.annotation.Gauge;
- import org.eclipse.microprofile.metrics.annotation.Metric;
- import org.eclipse.microprofile.metrics.annotation.Timed;
- 
+@@ -1,40 +1,45 @@
+ package quarkus.metric;
+
+-import org.eclipse.microprofile.metrics.Counter;
+-import org.eclipse.microprofile.metrics.MetricUnits;
+-import org.eclipse.microprofile.metrics.annotation.Gauge;
+-import org.eclipse.microprofile.metrics.annotation.Metric;
+-import org.eclipse.microprofile.metrics.annotation.Timed;
++import io.micrometer.core.instrument.Counter;
++import io.micrometer.core.instrument.MeterRegistry;
++import io.micrometer.core.instrument.Timer;
++import io.micrometer.core.instrument.Gauge;
+
 -import javax.enterprise.context.ApplicationScoped;
 -import javax.inject.Inject;
 -import javax.ws.rs.GET;
 -import javax.ws.rs.Path;
++import jakarta.annotation.PostConstruct;
 +import jakarta.enterprise.context.ApplicationScoped;
 +import jakarta.inject.Inject;
 +import jakarta.ws.rs.GET;
 +import jakarta.ws.rs.Path;
- 
+
  @Path("/metric")
  @ApplicationScoped
+ public class MetricController {
+
+     @Inject
+-    @Metric(name = "endpoint_counter")
+-    Counter counter;
++    MeterRegistry registry;
++
++    private Counter counter;
++
++    @PostConstruct
++    void init() {
++        counter = registry.counter("endpoint_counter");
++
++        Gauge.builder("counter_gauge", counter, Counter::count)
++                .description("Reports the current count of the endpoint_counter.")
++                .register(registry);
++    }
+
+     @Path("timed")
+-    @Timed(name = "timed-request")
+     @GET
+     public String timedRequest() {
+-        return "Request is used in statistics, check with the Metrics call.";
++        Timer timer = registry.timer("timed-request");
++        return timer.record(() -> "Request is used in statistics, check with the Metrics call.");
+     }
+
+     @Path("increment")
+     @GET
+     public long doIncrement() {
+-        counter.inc();
+-        return counter.getCount();
+-    }
+-
+-    @Gauge(name = "counter_gauge", unit = MetricUnits.NONE)
+-    long getCustomerCount() {
+-        return counter.getCount();
++        counter.increment();
++        return (long) counter.count();
+     }
+ }
+diff --git a/apps/quarkus-mp-orm-dbs-awt/src/test/java/quarkus/metric/MetricResourceTest.java b/apps/quarkus-mp-orm-dbs-awt/src/test/java/quarkus/metric/MetricResourceTest.java
+index 95b8ed8..0675512 100644
+--- a/apps/quarkus-mp-orm-dbs-awt/src/test/java/quarkus/metric/MetricResourceTest.java
++++ b/apps/quarkus-mp-orm-dbs-awt/src/test/java/quarkus/metric/MetricResourceTest.java
+@@ -21,6 +21,7 @@ public class MetricResourceTest {
+                 .when().get("q/metrics")
+                 .then()
+                 .statusCode(200)
+-                .body(containsStringIgnoringCase("MetricController_endpoint_counter_total 1.0"));
++                .body(containsStringIgnoringCase("endpoint_counter_total 1.0"))
++                .body(containsStringIgnoringCase("counter_gauge 1.0"));
+     }
+ }
 diff --git a/apps/quarkus-mp-orm-dbs-awt/src/main/java/quarkus/orm/EntityResource.java b/apps/quarkus-mp-orm-dbs-awt/src/main/java/quarkus/orm/EntityResource.java
 index 45c7190..fcf3094 100644
 --- a/apps/quarkus-mp-orm-dbs-awt/src/main/java/quarkus/orm/EntityResource.java
@@ -445,18 +518,3 @@ index b5f16ea..f0dcc9f 100644
  insert into db2entity (id, field) values(30, 'field-3');
  ALTER TABLE `db2entity` AUTO_INCREMENT = 40;
 -
-diff --git a/testsuite/src/it/java/org/graalvm/tests/integration/PerfCheckTest.java b/testsuite/src/it/java/org/graalvm/tests/integration/PerfCheckTest.java
-index e40a90a..b92b841 100644
---- a/testsuite/src/it/java/org/graalvm/tests/integration/PerfCheckTest.java
-+++ b/testsuite/src/it/java/org/graalvm/tests/integration/PerfCheckTest.java
-@@ -791,7 +791,9 @@ public class PerfCheckTest {
-         final String mn = testInfo.getTestMethod().get().getName();
-         String patch = null;
-         final List<Path> jsonPayloads = new ArrayList<>(2);
--        if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_21_0) >= 0) {
-+        if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_31_0) >= 0) {
-+            patch = "quarkus_3.31.x.patch";
-+        } else if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_21_0) >= 0) {
-             patch = "quarkus_3.21.x.patch";
-         } else if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_9_0) >= 0) {
-             patch = "quarkus_3.9.x.patch";

--- a/apps/quarkus-spöklik-encoding/quarkus_3.31.x.patch
+++ b/apps/quarkus-spöklik-encoding/quarkus_3.31.x.patch
@@ -1,0 +1,30 @@
+diff --git "a/apps/quarkus-sp\303\266klik-encoding/pom.xml" "b/apps/quarkus-sp\303\266klik-encoding/pom.xml"
+index 9fffa31..0bda3d3 100644
+--- "a/apps/quarkus-sp\303\266klik-encoding/pom.xml"
++++ "b/apps/quarkus-sp\303\266klik-encoding/pom.xml"
+@@ -42,6 +42,7 @@
+         <groupId>io.quarkus</groupId>
+         <artifactId>quarkus-maven-plugin</artifactId>
+         <version>${quarkus.version}</version>
++        <extensions>true</extensions>
+         <executions>
+           <execution>
+             <goals>
+diff --git "a/apps/quarkus-sp\303\266klik-encoding/src/main/java/org/acme/getting/started/\345\225\217\345\200\231Resource.java" "b/apps/quarkus-sp\303\266klik-encoding/src/main/java/org/acme/getting/started/\345\225\217\345\200\231Resource.java"
+index 80619cc..e902907 100644
+--- "a/apps/quarkus-sp\303\266klik-encoding/src/main/java/org/acme/getting/started/\345\225\217\345\200\231Resource.java"
++++ "b/apps/quarkus-sp\303\266klik-encoding/src/main/java/org/acme/getting/started/\345\225\217\345\200\231Resource.java"
+@@ -1,9 +1,9 @@
+ package org.acme.getting.started;
+
+-import javax.ws.rs.GET;
+-import javax.ws.rs.Path;
+-import javax.ws.rs.Produces;
+-import javax.ws.rs.core.MediaType;
++import jakarta.ws.rs.GET;
++import jakarta.ws.rs.Path;
++import jakarta.ws.rs.Produces;
++import jakarta.ws.rs.core.MediaType;
+
+ @Path("/sånt är livet")
+ public class 問候Resource {

--- a/apps/quarkus-vertx/quarkus_3.31.x.patch
+++ b/apps/quarkus-vertx/quarkus_3.31.x.patch
@@ -1,0 +1,243 @@
+diff --git a/apps/quarkus-vertx/pom.xml b/apps/quarkus-vertx/pom.xml
+index 7d47c9b..e23825e 100644
+--- a/apps/quarkus-vertx/pom.xml
++++ b/apps/quarkus-vertx/pom.xml
+@@ -36,11 +36,7 @@
+     <dependencies>
+         <dependency>
+             <groupId>io.quarkus</groupId>
+-            <artifactId>quarkus-resteasy</artifactId>
+-        </dependency>
+-        <dependency>
+-            <groupId>io.quarkus</groupId>
+-            <artifactId>quarkus-resteasy-mutiny</artifactId>
++            <artifactId>quarkus-rest</artifactId>
+         </dependency>
+         <dependency>
+             <groupId>io.quarkus</groupId>
+@@ -56,11 +52,7 @@
+         </dependency>
+         <dependency>
+             <groupId>io.quarkus</groupId>
+-            <artifactId>quarkus-resteasy-jsonb</artifactId>
+-        </dependency>
+-        <dependency>
+-            <groupId>io.smallrye.reactive</groupId>
+-            <artifactId>smallrye-mutiny-vertx-web-client</artifactId>
++            <artifactId>quarkus-rest-jsonb</artifactId>
+         </dependency>
+     </dependencies>
+     <build>
+@@ -74,6 +66,7 @@
+                 <groupId>io.quarkus</groupId>
+                 <artifactId>quarkus-maven-plugin</artifactId>
+                 <version>${quarkus.version}</version>
++                <extensions>true</extensions>
+                 <executions>
+                     <execution>
+                         <goals>
+diff --git a/apps/quarkus-vertx/src/main/java/org/acme/vertx/FruitResource.java b/apps/quarkus-vertx/src/main/java/org/acme/vertx/FruitResource.java
+index cf0796c..8cb6b0c 100644
+--- a/apps/quarkus-vertx/src/main/java/org/acme/vertx/FruitResource.java
++++ b/apps/quarkus-vertx/src/main/java/org/acme/vertx/FruitResource.java
+@@ -18,22 +18,22 @@ package org.acme.vertx;
+ 
+ import java.net.URI;
+ 
+-import javax.annotation.PostConstruct;
+-import javax.inject.Inject;
+-import javax.ws.rs.Consumes;
+-import javax.ws.rs.DELETE;
+-import javax.ws.rs.GET;
+-import javax.ws.rs.POST;
+-import javax.ws.rs.PUT;
+-import javax.ws.rs.Path;
+-import javax.ws.rs.Produces;
+-import javax.ws.rs.core.MediaType;
+-import javax.ws.rs.core.Response;
+-import javax.ws.rs.core.Response.ResponseBuilder;
+-import javax.ws.rs.core.Response.Status;
++import jakarta.annotation.PostConstruct;
++import jakarta.inject.Inject;
++import jakarta.ws.rs.Consumes;
++import jakarta.ws.rs.DELETE;
++import jakarta.ws.rs.GET;
++import jakarta.ws.rs.POST;
++import jakarta.ws.rs.PUT;
++import jakarta.ws.rs.Path;
++import jakarta.ws.rs.PathParam;
++import jakarta.ws.rs.Produces;
++import jakarta.ws.rs.core.MediaType;
++import jakarta.ws.rs.core.Response;
++import jakarta.ws.rs.core.Response.ResponseBuilder;
++import jakarta.ws.rs.core.Response.Status;
+ 
+ import org.eclipse.microprofile.config.inject.ConfigProperty;
+-import org.jboss.resteasy.annotations.jaxrs.PathParam;
+ 
+ import io.smallrye.mutiny.Uni;
+ import io.vertx.mutiny.pgclient.PgPool;
+@@ -43,29 +43,9 @@ import io.vertx.mutiny.pgclient.PgPool;
+ @Consumes(MediaType.APPLICATION_JSON)
+ public class FruitResource {
+ 
+-    @Inject
+-    @ConfigProperty(name = "myapp.schema.create", defaultValue = "true")
+-    boolean schemaCreate;
+-
+     @Inject
+     PgPool client;
+ 
+-    @PostConstruct
+-    void config() {
+-        if (schemaCreate) {
+-            initdb();
+-        }
+-    }
+-
+-    private void initdb() {
+-        client.query("DROP TABLE IF EXISTS fruits").execute()
+-                .flatMap(r -> client.query("CREATE TABLE fruits (id SERIAL PRIMARY KEY, name TEXT NOT NULL)").execute())
+-                .flatMap(r -> client.query("INSERT INTO fruits (name) VALUES ('Orange')").execute())
+-                .flatMap(r -> client.query("INSERT INTO fruits (name) VALUES ('Pear')").execute())
+-                .flatMap(r -> client.query("INSERT INTO fruits (name) VALUES ('Apple')").execute())
+-                .await().indefinitely();
+-    }
+-
+     @GET
+     public Uni<Response> get() {
+         return Fruit.findAll(client)
+@@ -75,7 +55,7 @@ public class FruitResource {
+ 
+     @GET
+     @Path("{id}")
+-    public Uni<Response> getSingle(@PathParam Long id) {
++    public Uni<Response> getSingle(@PathParam(value = "id") Long id) {
+         return Fruit.findById(client, id)
+                 .onItem().transform(fruit -> fruit != null ? Response.ok(fruit) : Response.status(Status.NOT_FOUND))
+                 .onItem().transform(ResponseBuilder::build);
+@@ -90,7 +70,7 @@ public class FruitResource {
+ 
+     @PUT
+     @Path("{id}")
+-    public Uni<Response> update(@PathParam Long id, Fruit fruit) {
++    public Uni<Response> update(@PathParam(value = "id") Long id, Fruit fruit) {
+         return fruit.update(client)
+                 .onItem().transform(updated -> updated ? Status.OK : Status.NOT_FOUND)
+                 .onItem().transform(status -> Response.status(status).build());
+@@ -98,7 +78,7 @@ public class FruitResource {
+ 
+     @DELETE
+     @Path("{id}")
+-    public Uni<Response> delete(@PathParam Long id) {
++    public Uni<Response> delete(@PathParam(value = "id") Long id) {
+         return Fruit.delete(client, id)
+                 .onItem().transform(deleted -> deleted ? Status.NO_CONTENT : Status.NOT_FOUND)
+                 .onItem().transform(status -> Response.status(status).build());
+diff --git a/apps/quarkus-vertx/src/main/java/org/acme/vertx/GreetingResource.java b/apps/quarkus-vertx/src/main/java/org/acme/vertx/GreetingResource.java
+index ac167a0..1b56c15 100644
+--- a/apps/quarkus-vertx/src/main/java/org/acme/vertx/GreetingResource.java
++++ b/apps/quarkus-vertx/src/main/java/org/acme/vertx/GreetingResource.java
+@@ -15,19 +15,17 @@
+  */
+ package org.acme.vertx;
+ 
+-import static java.util.concurrent.TimeUnit.MILLISECONDS;
+-import static java.util.concurrent.TimeUnit.NANOSECONDS;
+-
+-import javax.inject.Inject;
+-import javax.ws.rs.GET;
+-import javax.ws.rs.Path;
+-import javax.ws.rs.Produces;
+-import javax.ws.rs.core.MediaType;
+-
+-import org.jboss.resteasy.annotations.jaxrs.PathParam;
+-
+ import io.smallrye.mutiny.Uni;
+ import io.vertx.core.Vertx;
++import jakarta.inject.Inject;
++import jakarta.ws.rs.GET;
++import jakarta.ws.rs.Path;
++import jakarta.ws.rs.PathParam;
++import jakarta.ws.rs.Produces;
++import jakarta.ws.rs.core.MediaType;
++
++import static java.util.concurrent.TimeUnit.MILLISECONDS;
++import static java.util.concurrent.TimeUnit.NANOSECONDS;
+ 
+ @Path("/hello")
+ public class GreetingResource {
+@@ -38,7 +36,7 @@ public class GreetingResource {
+     @GET
+     @Produces(MediaType.TEXT_PLAIN)
+     @Path("{name}")
+-    public Uni<String> greeting(@PathParam String name) {
++    public Uni<String> greeting(@PathParam(value = "name") String name) {
+         return Uni.createFrom().emitter(emitter -> {
+             long start = System.nanoTime();
+             vertx.setTimer(10, l -> {
+diff --git a/apps/quarkus-vertx/src/main/java/org/acme/vertx/GreetingService.java b/apps/quarkus-vertx/src/main/java/org/acme/vertx/GreetingService.java
+index 0cb587a..ba16e14 100644
+--- a/apps/quarkus-vertx/src/main/java/org/acme/vertx/GreetingService.java
++++ b/apps/quarkus-vertx/src/main/java/org/acme/vertx/GreetingService.java
+@@ -15,7 +15,7 @@
+  */
+ package org.acme.vertx;
+ 
+-import javax.enterprise.context.ApplicationScoped;
++import jakarta.enterprise.context.ApplicationScoped;
+ 
+ import io.quarkus.vertx.ConsumeEvent;
+ 
+diff --git a/apps/quarkus-vertx/src/main/java/org/acme/vertx/VertxJsonResource.java b/apps/quarkus-vertx/src/main/java/org/acme/vertx/VertxJsonResource.java
+index cc9c525..4fc2fd4 100644
+--- a/apps/quarkus-vertx/src/main/java/org/acme/vertx/VertxJsonResource.java
++++ b/apps/quarkus-vertx/src/main/java/org/acme/vertx/VertxJsonResource.java
+@@ -15,13 +15,12 @@
+  */
+ package org.acme.vertx;
+ 
+-import javax.ws.rs.GET;
+-import javax.ws.rs.Path;
+-import javax.ws.rs.Produces;
+-import javax.ws.rs.core.MediaType;
+-
+-import org.jboss.resteasy.annotations.jaxrs.PathParam;
++import jakarta.ws.rs.GET;
++import jakarta.ws.rs.Path;
++import jakarta.ws.rs.Produces;
++import jakarta.ws.rs.core.MediaType;
+ 
++import jakarta.ws.rs.PathParam;
+ import io.vertx.core.json.JsonArray;
+ import io.vertx.core.json.JsonObject;
+ 
+@@ -31,13 +30,13 @@ public class VertxJsonResource {
+ 
+     @GET
+     @Path("{name}/object")
+-    public JsonObject jsonObject(@PathParam String name) {
++    public JsonObject jsonObject(@PathParam(value = "name") String name) {
+         return new JsonObject().put("Hello", name);
+     }
+ 
+     @GET
+     @Path("{name}/array")
+-    public JsonArray jsonArray(@PathParam String name) {
++    public JsonArray jsonArray(@PathParam(value = "name") String name) {
+         return new JsonArray().add("Hello").add(name);
+     }
+ }
+diff --git a/apps/quarkus-vertx/src/main/resources/application.properties b/apps/quarkus-vertx/src/main/resources/application.properties
+index 33ee4a9..138bc8d 100644
+--- a/apps/quarkus-vertx/src/main/resources/application.properties
++++ b/apps/quarkus-vertx/src/main/resources/application.properties
+@@ -5,4 +5,6 @@ quarkus.datasource.username=quarkus_test
+ quarkus.datasource.password=quarkus_test
+ quarkus.datasource.reactive.url=postgresql://localhost:5432/quarkus_test
+ 
+-myapp.schema.create=true
+\ No newline at end of file
++myapp.schema.create=true
++# A very long time, we hang in there during debugging.
++quarkus.vertx.max-event-loop-execute-time=2M

--- a/apps/quarkus-vertx/quarkus_3.31.x.patch
+++ b/apps/quarkus-vertx/quarkus_3.31.x.patch
@@ -241,3 +241,55 @@ index 33ee4a9..138bc8d 100644
 +myapp.schema.create=true
 +# A very long time, we hang in there during debugging.
 +quarkus.vertx.max-event-loop-execute-time=2M
+
+diff --git a/apps/quarkus-vertx/src/main/java/org/acme/vertx/FruitApp.java b/apps/quarkus-vertx/src/main/java/org/acme/vertx/FruitApp.java
+new file mode 100644
+index 0000000..b772382
+--- /dev/null
++++ b/apps/quarkus-vertx/src/main/java/org/acme/vertx/FruitApp.java
+@@ -0,0 +1,45 @@
++/*
++ * Copyright 2023 Red Hat, Inc.
++ *
++ * Red Hat licenses this file to you under the Apache License, version 2.0
++ * (the "License"); you may not use this file except in compliance with the
++ * License.  You may obtain a copy of the License at:
++ *
++ * http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
++ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
++ * License for the specific language governing permissions and limitations
++ * under the License.
++ */
++
++package org.acme.vertx;
++
++import io.quarkus.runtime.Startup;
++import io.vertx.mutiny.pgclient.PgPool;
++import jakarta.enterprise.context.ApplicationScoped;
++import jakarta.inject.Inject;
++import org.eclipse.microprofile.config.inject.ConfigProperty;
++
++@ApplicationScoped
++public class FruitApp {
++
++    @Inject
++    @ConfigProperty(name = "myapp.schema.create", defaultValue = "true")
++    boolean schemaCreate;
++
++    @Inject
++    PgPool client;
++
++    @Startup
++    void initdb() {
++        if (schemaCreate) {
++            client.query("DROP TABLE IF EXISTS fruits").execute()
++                    .flatMap(r -> client.query("CREATE TABLE fruits (id SERIAL PRIMARY KEY, name TEXT NOT NULL)").execute())
++                    .flatMap(r -> client.query("INSERT INTO fruits (name) VALUES ('Orange')").execute())
++                    .flatMap(r -> client.query("INSERT INTO fruits (name) VALUES ('Pear')").execute())
++                    .flatMap(r -> client.query("INSERT INTO fruits (name) VALUES ('Apple')").execute()).await().indefinitely();
++        }
++    }
++}

--- a/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/AppReproducersTest.java
@@ -1388,7 +1388,7 @@ public class AppReproducersTest {
             }
             return !BUILDER_RUNTIME_COMPATIBILITY.get("ubi8").contains(base);
         }
-        if (BUILDER_IMAGE.contains("/ubi9-")) {
+        if (BUILDER_IMAGE.contains("/ubi9-") || BUILDER_IMAGE.contains("rhel9")) {
             return !BUILDER_RUNTIME_COMPATIBILITY.get("ubi9").contains(base);
         }
         if (BUILDER_IMAGE.contains("/ubi10-")) {

--- a/testsuite/src/it/java/org/graalvm/tests/integration/DebugSymbolsTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/DebugSymbolsTest.java
@@ -333,7 +333,9 @@ public class DebugSymbolsTest {
                 runCommand(getRunCommand("git", "apply", "quarkus_sources.patch"), appDir);
             }
 
-            if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_9_0) >= 0) {
+            if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_31_0) >= 0) {
+                patch = "quarkus_3.31.x.patch";
+            } else if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_9_0) >= 0) {
                 patch = "quarkus_3.9.x.patch";
             } else if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_0_0) >= 0) {
                 patch = "quarkus_3.x.patch";

--- a/testsuite/src/it/java/org/graalvm/tests/integration/RuntimesSmokeTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/RuntimesSmokeTest.java
@@ -234,12 +234,17 @@ public class RuntimesSmokeTest {
     public void quarkusEncodingIssues(TestInfo testInfo) throws IOException, InterruptedException {
         Apps apps = Apps.QUARKUS_BUILDER_IMAGE_ENCODING;
         if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_0_0) >= 0) {
+            String patchFile = "quarkus_3.x.patch";
+            if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_31_0) >= 0) {
+                // Use new patch file for Quarkus 3.31.x and newer.
+                patchFile = "quarkus_3.31.x.patch";
+            }
             try {
-                runCommand(getRunCommand("git", "apply", "quarkus_3.x.patch"),
+                runCommand(getRunCommand("git", "apply", patchFile),
                         Path.of(BASE_DIR, apps.dir).toFile());
                 testRuntime(testInfo, apps);
             } finally {
-                runCommand(getRunCommand("git", "apply", "-R", "quarkus_3.x.patch"),
+                runCommand(getRunCommand("git", "apply", "-R", patchFile),
                         Path.of(BASE_DIR, apps.dir).toFile());
             }
         } else {

--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
@@ -359,6 +359,18 @@ public enum WhitelistLogLines {
             p.add(Pattern.compile(".*time=\".*\" level=warning msg=\"archive: skipping.*"));
             // sometimes showing up, probably caused by Jaeger not running
             p.add(Pattern.compile(".*Failed to export spans. The request could not be executed. Full error message: Client is closed.*"));
+            if (QUARKUS_VERSION.compareTo(new QuarkusVersion("3.31.3")) >= 0) {
+                // Noise that came up after upgrading to Quarkus 3.31.3 and using quarkus-micrometer-registry-prometheus
+                // instead of quarkus-smallrye-metrics.
+                p.add(Pattern.compile(".*WARNING: A Java agent has been loaded dynamically.*"));
+                p.add(Pattern.compile(".*WARNING: If a serviceability tool is in use, please run with -XX:\\+EnableDynamicAgentLoading to hide this warning.*"));
+                p.add(Pattern.compile(".*WARNING: If a serviceability tool is not in use, please run with -Djdk\\.instrument\\.traceUsage for more information.*"));
+                p.add(Pattern.compile(".*WARNING: Dynamic loading of agents will be disallowed by default in a future release.*"));
+                p.add(Pattern.compile(".*WARN.*\\[io\\.micrometer\\.core\\.instrument\\.MeterRegistry\\] \\(main\\) This Gauge has been already registered.*the registration will be ignored. Note that subsequent logs will be logged at debug level.*"));
+                p.add(Pattern.compile(".*\\[WARNING\\] Quarkus Maven extension: an explicit 'argLine' is defined in maven-surefire-plugin config, but does not contain '@\\{argLine\\}': we will not be able to inject JVM parameters automatically\\. Please add '@\\{argLine\\}' to the argLine configuration you have defined.*"));
+                p.add(Pattern.compile(".*WARN.*\\[io\\.quarkus\\.deployment\\.jvm] \\(main\\) Could not get access to jdk\\.internal\\.module API: this is required for Quarkus to adjust Java Modules configuration to match the various requirements of each extension\\. Please ensure this JVM is launched with --add-opens=java\\.base\\/java\\.lang\\.invoke=ALL-UNNAMED.*"));
+                p.add(Pattern.compile(".*WARN.*\\[org\\.testcontainers\\.utility\\.ResourceReaper\\] \\(build-[0-9]*\\).*"));
+            }
             return p.toArray(new Pattern[0]);
         }
     },


### PR DESCRIPTION
Hi, in this PR, the first batch of changes is implemented to make Mandrel 25 compatible with this testsuite.

1645ded:
- added `BUILDER_IMAGE.contains("rhel9")` to the condition in `isBuilderImageIncompatible()` method

222db1c:
- created a new patch (that is applied on Quarkus >= 3.31.0) in the spoklik-encoding app that adds `<extensions>true</extensions>` to the pom.xml

 aee61f3, cbd0684:
- same as above, but for the vertx app

6893e55:
- created a new patch (that is applied on Quarkus >= 3.31.0) in the mp-orm-dbs-awt app that replaces deprecated `quarkus-smallrye-metrics` with `quarkus-micrometer-registry-prometheus`
- rewrote the `MetricController.java` file in this patch to use the new metrics APIs 

017b1f1:
- the patch to mp-orm-dbs-awt created a few new warnings, they seemed unimportant, so I added them to the whitelist (please let me know if this doesn't make sense!)

I tested those changes on Hydra in an ARM job, and it looks like it works, it ran without failures.