### PR TITLE
Allow warning for using 23.1 instead of 25.0

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
@@ -61,6 +61,8 @@ public enum WhitelistLogLines {
             p.add(Pattern.compile(".*Warning: Please re-evaluate whether any experimental option is required, and either remove or unlock it\\..*"));
             // Quarkus main 2024-03-21 deprecates this maven plugin directive
             p.add(Pattern.compile(".*Configuration property 'quarkus.package.type' has been deprecated.*"));
+            // Allow the quarkus warning about older Mandrel/GraalVM versions
+            p.add(Pattern.compile(".*You are using an older version of GraalVM or Mandrel : 23\\.1.* Quarkus currently supports 25\\.0.* Please upgrade to this version\\..*"));
             // Microdnf complaining, benign
             p.add(Pattern.compile(".*microdnf.*Found 0 entitlement certificates.*"));
             // Podman, container image build


### PR DESCRIPTION
Prevents failures when using 23.1

Warning introduced with https://github.com/quarkusio/quarkus/pull/53820

Failure seen in https://github.com/graalvm/mandrel/actions/runs/25052464184/job/73389241996?pr=961