### PR TITLE
Fix regression in JfrTest

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/JFRTest.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/JFRTest.java
@@ -219,9 +219,7 @@ public class JFRTest {
                 switches = Map.of("-H:+SignalHandlerBasedExecutionSampler", "-H:+UnlockExperimentalVMOptions,-H:+SignalHandlerBasedExecutionSampler,-H:-UnlockExperimentalVMOptions");
             }
 
-            if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_4_0_0) >= 0) {
-                patch = "quarkus_4.0.x.patch";
-            } else if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_31_0) >= 0) {
+            if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_31_0) >= 0) {
                 patch = "quarkus_3.31.x.patch";
             } else if (QUARKUS_VERSION.compareTo(QuarkusVersion.V_3_9_0) >= 0) {
                 patch = "quarkus_3.9.x.patch";


### PR DESCRIPTION
#410 added a broken patch version for jfrPerfTest which doesn't actually use the quarkus-microprofile app. The patch file 4.0.x doesn't exist in the jfr-native-image-performance application. Applying a 4.0.x specific patch isn't necessary. Re-use the 3.31.x patch as before.

Closes: #411