### PR TITLE
Allow list netty boostrap log lines for JFR test runs

### DIFF
--- a/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/org/graalvm/tests/integration/utils/WhitelistLogLines.java
@@ -504,6 +504,8 @@ public enum WhitelistLogLines {
                 p.add(Pattern.compile(".*Waiting for container .* getting exit code of container .* from DB: no such exit code \\(container in state running\\).*"));
                 // Quarkus 3.x intermittently with JDK 20 based build...
                 p.add(Pattern.compile(".*io.net.boo.ServerBootstrap.*Failed to register an accepted channel:.*"));
+                // On quarkus 4.x we see this failure occasionally on Aarch64. See https://github.com/Karm/mandrel-integration-tests/issues/420
+                p.add(Pattern.compile(".*\\[io\\.netty\\.bootstrap\\.ServerBootstrap\\].*Failed to register an accepted channel:.*"));
                 // Perf test uses netty 4 which doesn't have the relevant native config in the lib. See https://github.com/netty/netty/pull/13596
                 p.add(Pattern.compile(".*Warning: The option '-H:ReflectionConfigurationResources=META-INF/native-image/io\\.netty/netty-transport/reflection-config\\.json' is experimental.*"));
                 if (IS_THIS_MACOS) {


### PR DESCRIPTION
I don't have a good way to test this other than integrating and seeing if it still persists.

The manual tests for two recent sightings are matching the pattern:
```
|  Welcome to JShell -- Version 25.0.3
|  For an introduction type: /help intro

jshell> var s = "2026-07-10 11:11:54,002 WARN  [io.netty.bootstrap.ServerBootstrap] (vert.x-acceptor-thread-0) Failed to register an accepted channel: [id: 0x97eecd50, L:/127.0.0.1:8080 ! R:/127.0.0.1:58564]: java.lang.IllegalStateException"
s ==> "2026-07-10 11:11:54,002 WARN  [io.netty.bootstra ... ang.IllegalStateException"

jshell> var s2 = "2026-07-05 01:06:10,632 WARN  [io.netty.bootstrap.ServerBootstrap] (vert.x-acceptor-thread-0) Failed to register an accepted channel: [id: 0x74a2ab51, L:/127.0.0.1:8080 ! R:/127.0.0.1:43416]: java.lang.IllegalStateException"
s2 ==> "2026-07-05 01:06:10,632 WARN  [io.netty.bootstra ... ang.IllegalStateException"

jshell> Pattern p = Pattern.compile(".*\\[io\\.netty\\.bootstrap\\.ServerBootstrap\\].*Failed to register an accepted channel:.*");
p ==> .*\[io\.netty\.bootstrap\.ServerBootstrap\].*Fail ... ter an accepted channel:.*

jshell> Matcher m = p.matcher(s);
m ==> java.util.regex.Matcher[pattern=.*\[io\.netty\.bo ... * region=0,223 lastmatch=]

jshell> m.matches()
$5 ==> true

jshell> Matcher m = p.matcher(s2);
m ==> java.util.regex.Matcher[pattern=.*\[io\.netty\.bo ... * region=0,223 lastmatch=]

jshell> m.matches()
$7 ==> true
```

Closes: #394 